### PR TITLE
Refactor project structure toward hexagonal architecture

### DIFF
--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub;
+namespace N3XT0R\XPub\Adapter;
 
-use N3XT0R\XPub\Core\PublisherFactory;
-use N3XT0R\XPub\Setup\SetupRunner;
+use N3XT0R\XPub\Application\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Setup\SetupRunner;
 use N3XT0R\XPub\Support\Version;
 
 /**
  * Main entry point for the WP-XPub plugin lifecycle (activation, boot, uninstall).
  */
-final class Plugin
+final class WordpressPlugin
 {
     private static string $pluginFile;
 

--- a/src/Application/PublisherFactory.php
+++ b/src/Application/PublisherFactory.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Core;
+namespace N3XT0R\XPub\Application;
 
-use N3XT0R\XPub\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
 
 class PublisherFactory {
     public static function create(string $target): PublisherInterface {
         $map = apply_filters('wp_xpub_factory_map', [
-            'devto' => \N3XT0R\XPub\Publishers\DevToPublisher::class,
+            'devto' => \N3XT0R\XPub\Infrastructure\Publishers\DevToPublisher::class,
         ]);
 
         if (!isset($map[$target]) || !class_exists($map[$target])) {

--- a/src/Domain/Contracts/PublisherInterface.php
+++ b/src/Domain/Contracts/PublisherInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Contracts;
+namespace N3XT0R\XPub\Domain\Contracts;
 
 interface PublisherInterface {
     public function publish(string $title, string $content): bool;

--- a/src/Infrastructure/Publishers/DevToPublisher.php
+++ b/src/Infrastructure/Publishers/DevToPublisher.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Publishers;
+namespace N3XT0R\XPub\Infrastructure\Publishers;
 
-use N3XT0R\XPub\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
 
 class DevToPublisher implements PublisherInterface {
     public function publish(string $title, string $content): bool {

--- a/src/Infrastructure/Wordpress/Database/Database.php
+++ b/src/Infrastructure/Wordpress/Database/Database.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Infrastructure\Database;
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Database;
 
 use wpdb;
 

--- a/src/Infrastructure/Wordpress/Logging/Handler/AdminNoticeHandler.php
+++ b/src/Infrastructure/Wordpress/Logging/Handler/AdminNoticeHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace N3XT0R\XPub\Infrastructure\Logging\Handler;
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Logging\Handler;
 
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Level;

--- a/src/Infrastructure/Wordpress/Logging/Handler/WPDBLogHandler.php
+++ b/src/Infrastructure/Wordpress/Logging/Handler/WPDBLogHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Infrastructure\Logging\Handler;
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Logging\Handler;
 
 
 use Monolog\Handler\AbstractProcessingHandler;

--- a/src/Infrastructure/Wordpress/Logging/LoggerFactory.php
+++ b/src/Infrastructure/Wordpress/Logging/LoggerFactory.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Infrastructure\Logging;
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Logging;
 
 use Monolog\Logger;
-use N3XT0R\XPub\Infrastructure\Database\Database;
-use N3XT0R\XPub\Infrastructure\Logging\Handler\AdminNoticeHandler;
-use N3XT0R\XPub\Infrastructure\Logging\Handler\WPDBLogHandler;
+use N3XT0R\XPub\Infrastructure\Wordpress\Database\Database;
+use N3XT0R\XPub\Infrastructure\Wordpress\Logging\Handler\AdminNoticeHandler;
+use N3XT0R\XPub\Infrastructure\Wordpress\Logging\Handler\WPDBLogHandler;
 
 class LoggerFactory
 {

--- a/src/Infrastructure/Wordpress/Setup/Migrations/AbstractMigration.php
+++ b/src/Infrastructure/Wordpress/Setup/Migrations/AbstractMigration.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Setup\Migrations;
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Setup\Migrations;
 
 use Monolog\Logger;
-use N3XT0R\XPub\Infrastructure\Database\Database;
-use N3XT0R\XPub\Infrastructure\Logging\LoggerFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Database\Database;
+use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use wpdb as WPDB;
 
 abstract class AbstractMigration

--- a/src/Infrastructure/Wordpress/Setup/Migrations/Migration_1.php
+++ b/src/Infrastructure/Wordpress/Setup/Migrations/Migration_1.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Setup\Migrations;
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Setup\Migrations;
 
 use wpdb;
 

--- a/src/Infrastructure/Wordpress/Setup/SetupRunner.php
+++ b/src/Infrastructure/Wordpress/Setup/SetupRunner.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Setup;
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Setup;
 
-use N3XT0R\XPub\Setup\Migrations\AbstractMigration;
+use N3XT0R\XPub\Infrastructure\Wordpress\Setup\Migrations\AbstractMigration;
 
 /**
  * Executes and manages all available plugin migrations.
@@ -18,7 +18,7 @@ use N3XT0R\XPub\Setup\Migrations\AbstractMigration;
 class SetupRunner
 {
     public const OPTION_KEY = 'xpub_db_version';
-    public const MIGRATION_NAMESPACE = 'N3XT0R\\XPub\\Setup\\Migrations\\';
+    public const MIGRATION_NAMESPACE = 'N3XT0R\\XPub\\Infrastructure\\Wordpress\\Setup\\Migrations\\';
 
     public function install(): void
     {

--- a/xpub.php
+++ b/xpub.php
@@ -9,4 +9,4 @@ defined('ABSPATH') or die('No script kiddies please!');
 
 require_once __DIR__.'/vendor/autoload.php';
 
-\N3XT0R\XPub\Plugin::init(__FILE__);
+\N3XT0R\XPub\Adapter\WordpressPlugin::init(__FILE__);


### PR DESCRIPTION
## Summary
- reorganize code into Domain, Application, Infrastructure, and Adapter layers
- rename Plugin class to `WordpressPlugin`
- move WordPress-related utilities under Infrastructure\Wordpress
- update namespaces throughout

## Testing
- `composer dump-autoload`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68812b977b3c8329a55ab7af398092c9