### PR TITLE
Add unit test suite skeleton

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="WP-XPub Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Application/Factory/PublisherFactoryTest.php
+++ b/tests/Application/Factory/PublisherFactoryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Application\Factory\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Publishers\DevToPublisher;
+
+class PublisherFactoryTest extends TestCase
+{
+    public function testCreateReturnsPublisher(): void
+    {
+        $publisher = PublisherFactory::createWithConfig('devto', ['api_key' => 'k']);
+        $this->assertInstanceOf(DevToPublisher::class, $publisher);
+    }
+
+    public function testUnknownPublisherThrows(): void
+    {
+        $this->expectException(RuntimeException::class);
+        PublisherFactory::create('unknown');
+    }
+}

--- a/tests/Domain/Entity/ArticleTest.php
+++ b/tests/Domain/Entity/ArticleTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Domain\Entity\Article;
+
+class ArticleTest extends TestCase
+{
+    public function testCanCreateArticle(): void
+    {
+        $article = new Article(1, 'Title', 'Content');
+        $this->assertSame(1, $article->postId);
+        $this->assertSame('Title', $article->title);
+        $this->assertSame('Content', $article->content);
+    }
+
+    public function testRequiresTitleAndContent(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Article(1, '', '');
+    }
+}

--- a/tests/Domain/Entity/PublisherConfigTest.php
+++ b/tests/Domain/Entity/PublisherConfigTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Domain\Entity\PublisherConfig;
+
+class PublisherConfigTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $config = new PublisherConfig('api_key', 'secret');
+        $this->assertSame('api_key', $config->getKey());
+        $this->assertSame('secret', $config->getValue());
+    }
+}

--- a/tests/Domain/Entity/PublisherTest.php
+++ b/tests/Domain/Entity/PublisherTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Domain\Entity\PublisherConfig;
+
+class PublisherTest extends TestCase
+{
+    public function testConfigArrayRetrieval(): void
+    {
+        $publisher = new Publisher('devto', 'DevTo', [
+            new PublisherConfig('api_key', 'secret')
+        ]);
+
+        $this->assertSame('devto', $publisher->getSlug());
+        $this->assertSame(['api_key' => 'secret'], $publisher->getConfigArray());
+        $this->assertSame('secret', $publisher->getConfigByKey('api_key'));
+    }
+}

--- a/tests/Domain/Service/ArticlePublisherTest.php
+++ b/tests/Domain/Service/ArticlePublisherTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Domain\Service\ArticlePublisher;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Entity\Article;
+
+class ArticlePublisherTest extends TestCase
+{
+    public function testPublishCallsPublishers(): void
+    {
+        $publisher = $this->createMock(PublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->willReturn(true);
+
+        $articlePublisher = new ArticlePublisher([$publisher]);
+        $articlePublisher->publish(new Article(1, 'title', 'content'));
+    }
+}

--- a/tests/Domain/Service/PublisherTargetProviderTest.php
+++ b/tests/Domain/Service/PublisherTargetProviderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
+use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
+
+class PublisherTargetProviderTest extends TestCase
+{
+    public function testReturnsTargetsArray(): void
+    {
+        $settings = new class implements SettingsRepositoryInterface {
+            public function get(string $key, mixed $default = null): mixed {
+                return ['devto'];
+            }
+            public function set(string $key, mixed $value): bool { return true; }
+            public function delete(string $key): bool { return true; }
+        };
+
+        $provider = new PublisherTargetProvider($settings);
+        $this->assertSame(['devto'], $provider->getTargets());
+    }
+}

--- a/tests/Infrastructure/Markdown/HtmlToMarkdownRendererTest.php
+++ b/tests/Infrastructure/Markdown/HtmlToMarkdownRendererTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Infrastructure\Markdown\HtmlToMarkdownRenderer;
+
+class HtmlToMarkdownRendererTest extends TestCase
+{
+    public function testConvert(): void
+    {
+        $renderer = new HtmlToMarkdownRenderer();
+        $markdown = $renderer->convert('<h1>Title</h1><p>text</p>');
+        $this->assertStringContainsString('# Title', $markdown);
+        $this->assertStringContainsString('text', $markdown);
+    }
+}

--- a/tests/Support/VersionTest.php
+++ b/tests/Support/VersionTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use N3XT0R\XPub\Support\Version;
+
+class VersionTest extends TestCase
+{
+    public function testReturnsDefinedConstant(): void
+    {
+        define('XPUB_VERSION', '1.2.3');
+        $this->assertSame('1.2.3', Version::get());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,42 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value) { return $value; }
+}
+if (!function_exists('do_action')) {
+    function do_action($tag, ...$args) {}
+}
+if (!function_exists('wp_strip_all_tags')) {
+    function wp_strip_all_tags($text) { return strip_tags($text); }
+}
+if (!function_exists('wp_remote_post')) {
+    function wp_remote_post($url, $args = []) { return ['response' => ['code' => 200]]; }
+}
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing) { return false; }
+}
+if (!function_exists('wp_remote_retrieve_response_code')) {
+    function wp_remote_retrieve_response_code($response) { return $response['response']['code'] ?? 500; }
+}
+if (!function_exists('wp_remote_retrieve_body')) {
+    function wp_remote_retrieve_body($response) { return ''; }
+}
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) { return json_encode($data); }
+}
+if (!function_exists('__')) {
+    function __($text, $domain = 'default') { return $text; }
+}
+if (!function_exists('add_action')) { function add_action() {} }
+if (!function_exists('add_meta_box')) { function add_meta_box() {} }
+if (!function_exists('update_option')) { function update_option() {} }
+if (!function_exists('get_post_meta')) { function get_post_meta() { return ''; } }
+if (!function_exists('sanitize_textarea_field')) { function sanitize_textarea_field($text) { return $text; } }
+if (!function_exists('wp_verify_nonce')) { function wp_verify_nonce() { return true; } }
+if (!function_exists('current_user_can')) { function current_user_can() { return true; } }
+if (!function_exists('update_post_meta')) { function update_post_meta() {} }
+if (!function_exists('is_admin')) { function is_admin() { return true; } }
+if (!function_exists('wp_get_post_tags')) { function wp_get_post_tags() { return []; } }
+if (!function_exists('wp_reset_postdata')) { function wp_reset_postdata() {} }
+if (!function_exists('wp_kses_post')) { function wp_kses_post($content) { return $content; } }


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and bootstrap with WP stubs
- implement basic tests for a subset of domain classes and utilities

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6886ba39ffdc8329894409e36dd455ce