### PR TITLE
Add WP class stubs and new tests

### DIFF
--- a/tests/Infrastructure/Wordpress/Content/WpPostContentRendererTest.php
+++ b/tests/Infrastructure/Wordpress/Content/WpPostContentRendererTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Content;
+
+use N3XT0R\XPub\Infrastructure\Wordpress\Content\WpPostContentRenderer;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+function apply_filters($tag, $value) {
+    return strtoupper($value);
+}
+function setup_postdata($post) {
+    $GLOBALS['setup_called'] = $post->ID;
+}
+function wp_reset_postdata() {
+    $GLOBALS['reset_called'] = true;
+}
+function wp_kses_post($content) { return strip_tags($content); }
+
+class WpPostContentRendererTest extends TestCase
+{
+    public function testRenderProcessesContent(): void
+    {
+        $renderer = new WpPostContentRenderer();
+        $post = new WP_Post(['ID' => 5, 'post_content' => '<b>content</b>']);
+        $result = $renderer->render($post);
+
+        $this->assertSame('CONTENT', $result);
+        $this->assertSame(5, $GLOBALS['setup_called']);
+        $this->assertTrue($GLOBALS['reset_called']);
+    }
+
+    public function testRenderReturnsEmptyStringForEmptyContent(): void
+    {
+        $renderer = new WpPostContentRenderer();
+        $post = new WP_Post(['ID' => 6, 'post_content' => '']);
+        $this->assertSame('', $renderer->render($post));
+    }
+}

--- a/tests/Infrastructure/Wordpress/Factory/ArticleFactoryTest.php
+++ b/tests/Infrastructure/Wordpress/Factory/ArticleFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Factory;
+
+use N3XT0R\XPub\Infrastructure\Wordpress\Factory\ArticleFactory;
+use N3XT0R\XPub\Domain\Contracts\RendersPostContentInterface;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+function get_post_meta($postId, $key, $single = false) {
+    if ($key === '_xpub_custom_excerpt') {
+        return 'excerpt';
+    }
+    return '';
+}
+
+function get_permalink($post): string {
+    return 'http://example.com/' . $post->ID;
+}
+
+function wp_get_post_tags($postId, $args) {
+    return ['one', 'two'];
+}
+
+class ArticleFactoryTest extends TestCase
+{
+    public function testFromWpPostCreatesArticle(): void
+    {
+        $renderer = $this->createMock(RendersPostContentInterface::class);
+        $renderer->method('render')->willReturn('<html></html>');
+
+        $post = new WP_Post([
+            'ID' => 1,
+            'post_title' => 'Title',
+            'post_content' => 'Content',
+            'post_excerpt' => '',
+        ]);
+
+        $factory = new ArticleFactory($renderer);
+        $article = $factory->fromWpPost($post);
+
+        $this->assertSame(1, $article->postId);
+        $this->assertSame('Title', $article->title);
+        $this->assertSame('Content', $article->content);
+        $this->assertSame('excerpt', $article->excerpt);
+        $this->assertSame('http://example.com/1', $article->url);
+        $this->assertSame('<html></html>', $article->htmlContent);
+        $this->assertSame(['one', 'two'], $article->tags);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,3 +40,26 @@ if (!function_exists('is_admin')) { function is_admin() { return true; } }
 if (!function_exists('wp_get_post_tags')) { function wp_get_post_tags() { return []; } }
 if (!function_exists('wp_reset_postdata')) { function wp_reset_postdata() {} }
 if (!function_exists('wp_kses_post')) { function wp_kses_post($content) { return $content; } }
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($post): string { return ''; }
+}
+if (!function_exists('setup_postdata')) { function setup_postdata($post) {} }
+
+if (!class_exists('WP_Post')) {
+    class WP_Post
+    {
+        public int $ID;
+        public string $post_title = '';
+        public string $post_content = '';
+        public string $post_excerpt = '';
+        public string $post_status = '';
+
+        public function __construct(array $data = [])
+        {
+            foreach ($data as $key => $value) {
+                $this->$key = $value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WP_Post` stub and other WordPress helper stubs for tests
- test `ArticleFactory` using a stubbed `WP_Post`
- test `WpPostContentRenderer` logic

## Testing
- `./vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886c92809908329979aa67def016671