### PR TITLE
Add additional PHPUnit tests

### DIFF
--- a/tests/Infrastructure/Publishers/DevToPublisherTest.php
+++ b/tests/Infrastructure/Publishers/DevToPublisherTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Infrastructure\Publishers;
+
+use N3XT0R\XPub\Domain\Entity\Article;
+use N3XT0R\XPub\Infrastructure\Publishers\DevToPublisher;
+use PHPUnit\Framework\TestCase;
+
+class DevToPublisherTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wp_remote_post_response']);
+    }
+
+    public function testPublishFailsWithoutApiKey(): void
+    {
+        $publisher = new DevToPublisher();
+        $publisher->setConfig(['api_key' => '']);
+        $result = $publisher->publish(new Article(1, 't', 'c'));
+        $this->assertFalse($result);
+    }
+
+    public function testPublishSucceedsWith201Response(): void
+    {
+        $GLOBALS['wp_remote_post_response'] = ['response' => ['code' => 201], 'body' => ''];
+        $publisher = new DevToPublisher();
+        $publisher->setConfig(['api_key' => 'abc']);
+        $result = $publisher->publish(new Article(2, 't', 'c'));
+        $this->assertTrue($result);
+    }
+
+    public function testPublishFailsWithUnexpectedResponse(): void
+    {
+        $GLOBALS['wp_remote_post_response'] = ['response' => ['code' => 400], 'body' => 'bad'];
+        $publisher = new DevToPublisher();
+        $publisher->setConfig(['api_key' => 'abc']);
+        $result = $publisher->publish(new Article(3, 't', 'c'));
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Infrastructure/Wordpress/Logging/AdminNoticeHandlerTest.php
+++ b/tests/Infrastructure/Wordpress/Logging/AdminNoticeHandlerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Logging;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+use N3XT0R\XPub\Infrastructure\Wordpress\Logging\Handler\AdminNoticeHandler;
+use PHPUnit\Framework\TestCase;
+
+class AdminNoticeHandlerTest extends TestCase
+{
+    public function testStoresNoticeWhenErrorLevel(): void
+    {
+        global $wp_options;
+        $wp_options = [];
+
+        $handler = new AdminNoticeHandler();
+        $record = new LogRecord(new \DateTimeImmutable(), 'chan', Level::Error, 'msg');
+        $handler->handle($record);
+
+        $this->assertSame('msg', $wp_options['xpub_admin_notice'] ?? null);
+    }
+}

--- a/tests/Infrastructure/Wordpress/Logging/WPDBLogHandlerTest.php
+++ b/tests/Infrastructure/Wordpress/Logging/WPDBLogHandlerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Logging;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+use N3XT0R\XPub\Infrastructure\Wordpress\Logging\Handler\WPDBLogHandler;
+use PHPUnit\Framework\TestCase;
+
+class WPDBLogHandlerTest extends TestCase
+{
+    public function testInsertCalledWithCorrectData(): void
+    {
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+            public array $lastInsert = [];
+            public function insert($table, $data) { $this->lastInsert = [$table, $data]; }
+        };
+
+        $handler = new WPDBLogHandler($wpdb);
+        $record = new LogRecord(new \DateTimeImmutable(), 'chan', Level::Info, 'hi');
+        $handler->handle($record);
+
+        $this->assertSame('wp_xpub_logs', $wpdb->lastInsert[0]);
+        $this->assertSame('hi', $wpdb->lastInsert[1]['message']);
+    }
+}

--- a/tests/Infrastructure/Wordpress/Presentation/AdminNoticePresenterTest.php
+++ b/tests/Infrastructure/Wordpress/Presentation/AdminNoticePresenterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Presentation;
+
+use N3XT0R\XPub\Infrastructure\Wordpress\Presentation\AdminNoticePresenter;
+use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+class AdminNoticePresenterTest extends TestCase
+{
+    private function repoWithMessage(string $msg): SettingsRepositoryInterface
+    {
+        return new class($msg) implements SettingsRepositoryInterface {
+            private array $data;
+            public function __construct(string $msg) { $this->data['xpub_admin_notice'] = $msg; }
+            public function get(string $key, mixed $default = null): mixed { return $this->data[$key] ?? $default; }
+            public function set(string $key, mixed $value): bool { $this->data[$key] = $value; return true; }
+            public function delete(string $key): bool { unset($this->data[$key]); return true; }
+        };
+    }
+
+    public function testShowOutputsNoticeAndDeletesOption(): void
+    {
+        $repo = $this->repoWithMessage('hello');
+        $presenter = new AdminNoticePresenter($repo);
+
+        ob_start();
+        $presenter->showIfAvailable();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('hello', $output);
+        $this->assertNull($repo->get('xpub_admin_notice'));
+    }
+}

--- a/tests/Infrastructure/Wordpress/Setup/PublisherSeederTest.php
+++ b/tests/Infrastructure/Wordpress/Setup/PublisherSeederTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Setup;
+
+use InvalidArgumentException;
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Domain\Entity\PublisherConfig;
+use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Infrastructure\Wordpress\Setup\Seeder\PublisherSeeder;
+use PHPUnit\Framework\TestCase;
+
+class PublisherSeederTest extends TestCase
+{
+    public function testRegisterThrowsOnMissingConfig(): void
+    {
+        $repo = new class implements PublisherRepositoryInterface {
+            public function all(): array { return []; }
+            public function findBySlug(string $slug): ?Publisher { return null; }
+            public function updateConfig(string $slug, array $newConfig): bool { return true; }
+            public function create(string $slug, string $name, array $config): bool { return true; }
+        };
+
+        $seeder = new PublisherSeeder($repo);
+        $this->expectException(InvalidArgumentException::class);
+        $seeder->register('slug', 'name', []);
+    }
+
+    public function testUpsertUpdatesExistingConfig(): void
+    {
+        $updated = [];
+        $repo = new class(&$updated) implements PublisherRepositoryInterface {
+            private array $updated;
+            public function __construct(&$u) { $this->updated =& $u; }
+            public function all(): array { return []; }
+            public function findBySlug(string $slug): ?Publisher { return new Publisher($slug, 'name', [new PublisherConfig('api_key', '')]); }
+            public function updateConfig(string $slug, array $newConfig): bool { $this->updated[$slug] = $newConfig; return true; }
+            public function create(string $slug, string $name, array $config): bool { return true; }
+        };
+
+        $seeder = new PublisherSeeder($repo);
+        $seeder->upsert('slug', 'name', ['api_key' => 'abc']);
+        $this->assertSame(['api_key' => 'abc'], $updated['slug']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,10 @@
 
 require __DIR__.'/../vendor/autoload.php';
 
+// Globals used by WP function stubs
+$GLOBALS['wp_options'] = [];
+$GLOBALS['wp_remote_post_response'] = ['response' => ['code' => 200], 'body' => ''];
+
 if (!function_exists('apply_filters')) {
     function apply_filters($tag, $value)
     {
@@ -22,7 +26,7 @@ if (!function_exists('wp_strip_all_tags')) {
 if (!function_exists('wp_remote_post')) {
     function wp_remote_post($url, $args = [])
     {
-        return ['response' => ['code' => 200]];
+        return $GLOBALS['wp_remote_post_response'];
     }
 }
 if (!function_exists('is_wp_error')) {
@@ -40,7 +44,7 @@ if (!function_exists('wp_remote_retrieve_response_code')) {
 if (!function_exists('wp_remote_retrieve_body')) {
     function wp_remote_retrieve_body($response)
     {
-        return '';
+        return $response['body'] ?? '';
     }
 }
 if (!function_exists('wp_json_encode')) {
@@ -55,6 +59,12 @@ if (!function_exists('__')) {
         return $text;
     }
 }
+if (!function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return htmlspecialchars($text, ENT_QUOTES);
+    }
+}
 if (!function_exists('add_action')) {
     function add_action()
     {
@@ -66,8 +76,25 @@ if (!function_exists('add_meta_box')) {
     }
 }
 if (!function_exists('update_option')) {
-    function update_option()
+    function update_option($key, $value)
     {
+        $GLOBALS['wp_options'][$key] = $value;
+        return true;
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($key, $default = null)
+    {
+        return $GLOBALS['wp_options'][$key] ?? $default;
+    }
+}
+
+if (!function_exists('delete_option')) {
+    function delete_option($key)
+    {
+        unset($GLOBALS['wp_options'][$key]);
+        return true;
     }
 }
 if (!function_exists('get_post_meta')) {


### PR DESCRIPTION
## Summary
- expand WP bootstrap with option stubs and remote-post controls
- add tests for DevToPublisher
- cover AdminNotice handler and presenter
- test PublisherSeeder behaviour
- test WPDB log handler

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6886ce2325908329ae341ac67e1a0dad