### PR TITLE
Add DI container usage across adapters

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -1,7 +1,58 @@
 <?php
 
-use N3XT0R\XPub\Adapter\Outbound\Publishers\WordpressPublisher;
-use N3XT0R\XPub\Application\Service\PublishPost;
+declare(strict_types=1);
+
+use function DI\autowire;
+use function DI\create;
+use function DI\factory;
+use function DI\get;
+
+use N3XT0R\XPub\Application\Update\ReleaseService;
+use N3XT0R\XPub\Domain\Contracts\Factory\ArticleFactoryInterface;
+use N3XT0R\XPub\Domain\Contracts\Factory\WordpressArticleFactoryInterface;
+use N3XT0R\XPub\Domain\Contracts\HtmlToMarkdownRendererInterface;
+use N3XT0R\XPub\Domain\Contracts\ReleaseProviderInterface;
+use N3XT0R\XPub\Domain\Contracts\RendersPostContentInterface;
+use N3XT0R\XPub\Domain\Contracts\TranslatesMessagesInterface;
+use N3XT0R\XPub\Domain\Contracts\ViewInterface;
+use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
+use N3XT0R\XPub\Domain\Hook\HookDispatcherInterface;
+use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
+use N3XT0R\XPub\Domain\Contracts\QueueRepositoryInterface;
+use N3XT0R\XPub\Infrastructure\Markdown\HtmlToMarkdownRendererFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Content\WpPostContentRenderer;
+use N3XT0R\XPub\Infrastructure\Wordpress\Database\Database;
+use N3XT0R\XPub\Infrastructure\Wordpress\Factory\ArticleFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressFilterDispatcher;
+use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookDispatcher;
+use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
+use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WPDBQueueRepository;
+use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
+use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
+use N3XT0R\XPub\Infrastructure\Wordpress\I18n\Translator;
+use Psr\Log\LoggerInterface;
 
 return [
+    // Core repositories and services
+    SettingsRepositoryInterface::class => autowire(WordpressSettingsRepository::class),
+    PublisherRepositoryInterface::class => autowire(PublisherRepository::class),
+    QueueRepositoryInterface::class => factory(fn () => new WPDBQueueRepository(Database::get())),
+
+    // Factories and helpers
+    ArticleFactoryInterface::class => autowire(ArticleFactory::class),
+    WordpressArticleFactoryInterface::class => get(ArticleFactory::class),
+    RendersPostContentInterface::class => autowire(WpPostContentRenderer::class),
+    HtmlToMarkdownRendererInterface::class => factory([HtmlToMarkdownRendererFactory::class, 'create']),
+
+    // Views & translations
+    ViewInterface::class => create(View::class),
+    TranslatesMessagesInterface::class => create(Translator::class),
+
+    // Other utilities
+    ReleaseProviderInterface::class => autowire(ReleaseService::class),
+    FilterDispatcherInterface::class => create(WordpressFilterDispatcher::class),
+    HookDispatcherInterface::class => create(WordpressHookDispatcher::class),
+    LoggerInterface::class => factory([LoggerFactory::class, 'create']),
 ];

--- a/src/Adapter/WordpressCron.php
+++ b/src/Adapter/WordpressCron.php
@@ -1,19 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace N3XT0R\XPub\Adapter;
 
+use DI\Container;
 use N3XT0R\XPub\Application\Factory\PublisherFactory;
-use N3XT0R\XPub\Application\Publisher\PublisherSelector;
 use N3XT0R\XPub\Application\Service\Queue\JobRunner;
-use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
-use N3XT0R\XPub\Infrastructure\Wordpress\Content\WpPostContentRenderer;
-use N3XT0R\XPub\Infrastructure\Wordpress\Database\Database;
-use N3XT0R\XPub\Infrastructure\Wordpress\Factory\ArticleFactory;
-use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressFilterDispatcher;
-use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
-use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
-use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WPDBQueueRepository;
-use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
+use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
+use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
 
 final class WordpressCron
 {
@@ -21,8 +16,20 @@ final class WordpressCron
     public const CRON_SCHEDULE = 'xpub_every_minute';
     private const CRON_INTERVAL = 60;
 
+    private static ?Container $container = null;
+
+    private static function container(): Container
+    {
+        if (self::$container === null) {
+            self::$container = ContainerProvider::getContainer();
+        }
+
+        return self::$container;
+    }
+
     public static function init(): void
     {
+        self::container();
         add_filter('cron_schedules', [self::class, 'addSchedule']);
         add_action(self::CRON_HOOK, [self::class, 'run']);
     }
@@ -56,22 +63,12 @@ final class WordpressCron
         }
     }
 
-
     public static function run(): void
     {
-        PublisherFactory::setFilterDispatcher(new WordpressFilterDispatcher());
-        $jobRunner = new JobRunner(
-            queue: new WPDBQueueRepository(Database::get()),
-            publisherSelector: new PublisherSelector(
-                new PublisherRepository(),
-                new PublisherTargetProvider(new WordpressSettingsRepository()),
-                new PublisherFactory(),
-                LoggerFactory::create()
-            ),
-            articleFactory: new ArticleFactory(new WpPostContentRenderer()),
-            logger: LoggerFactory::create(),
+        PublisherFactory::setFilterDispatcher(
+            self::container()->get(FilterDispatcherInterface::class)
         );
-
+        $jobRunner = self::container()->get(JobRunner::class);
         $jobRunner->run();
     }
 }

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -5,23 +5,19 @@ declare(strict_types=1);
 namespace N3XT0R\XPub\Adapter;
 
 use N3XT0R\XPub\Application\Factory\PublisherFactory;
-use N3XT0R\XPub\Application\Publisher\PublisherSelector;
 use N3XT0R\XPub\Application\Service\Queue\AsyncPublishingDispatcher;
-use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
-use N3XT0R\XPub\Infrastructure\Wordpress\Content\WpPostContentRenderer;
-use N3XT0R\XPub\Infrastructure\Wordpress\Database\Database;
 use N3XT0R\XPub\Infrastructure\Wordpress\Factory\ArticleFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
-use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressFilterDispatcher;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Presentation\AdminNoticePresenter;
-use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
-use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WPDBQueueRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Service\Plugin\PluginBootstrapService;
-use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Setup\SetupRunner;
 use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
+use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
+use DI\Container;
+use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
+use N3XT0R\XPub\Domain\Hook\HookDispatcherInterface;
 use WP_Post;
 
 /**
@@ -30,15 +26,31 @@ use WP_Post;
  */
 final class WordpressPlugin
 {
+    private static ?Container $container = null;
+
+    private static function container(): Container
+    {
+        if (self::$container === null) {
+            self::$container = ContainerProvider::getContainer();
+        }
+
+        return self::$container;
+    }
 
     /**
      * Initializes the plugin and registers hooks.
      */
     public static function init(string $pluginFile): void
     {
+        self::container();
         View::setBasePath(plugin_dir_path(__FILE__).'../../resources/views');
-        PublisherFactory::setFilterDispatcher(new WordpressFilterDispatcher());
-        $registrar = new WordpressHookRegistrar(new HookProvider($pluginFile));
+        PublisherFactory::setFilterDispatcher(
+            self::container()->get(FilterDispatcherInterface::class)
+        );
+        $registrar = new WordpressHookRegistrar(
+            new HookProvider($pluginFile),
+            self::container()->get(HookDispatcherInterface::class)
+        );
         $registrar->register($pluginFile);
     }
 
@@ -47,8 +59,9 @@ final class WordpressPlugin
      */
     public static function boot(): void
     {
-        $bootstrapper = new PluginBootstrapService(new WordpressSettingsRepository());
-        $bootstrapper->bootstrap();
+        self::container()
+            ->get(PluginBootstrapService::class)
+            ->bootstrap();
     }
 
     /**
@@ -56,11 +69,9 @@ final class WordpressPlugin
      */
     public static function onActivate(string $channel = 'xpub'): void
     {
-        $runner = new SetupRunner(
-            LoggerFactory::create($channel),
-            new WordpressSettingsRepository()
-        );
-        $runner->install();
+        self::container()
+            ->make(SetupRunner::class, ['logger' => LoggerFactory::create($channel)])
+            ->install();
         WordpressCron::schedule();
     }
 
@@ -69,11 +80,9 @@ final class WordpressPlugin
      */
     public static function onUninstall(string $channel = 'xpub'): void
     {
-        $runner = new SetupRunner(
-            LoggerFactory::create($channel),
-            new WordpressSettingsRepository()
-        );
-        $runner->uninstall();
+        self::container()
+            ->make(SetupRunner::class, ['logger' => LoggerFactory::create($channel)])
+            ->uninstall();
         WordpressCron::unschedule();
     }
 
@@ -82,8 +91,9 @@ final class WordpressPlugin
      */
     public static function showAdminNotice(): void
     {
-        $presenter = new AdminNoticePresenter(new WordpressSettingsRepository());
-        $presenter->showIfAvailable();
+        self::container()
+            ->get(AdminNoticePresenter::class)
+            ->showIfAvailable();
     }
 
     public static function handlePublishFromPost(int $postId, ?WP_Post $post): void
@@ -98,24 +108,16 @@ final class WordpressPlugin
             return;
         }
 
-
         $dispatcher = self::getDispatcher();
-        $article = (new ArticleFactory(new WpPostContentRenderer()))->fromWpPost($post);
+        $article = self::container()
+            ->get(ArticleFactory::class)
+            ->fromWpPost($post);
         $dispatcher->dispatch($article);
     }
 
     private static function getDispatcher(): AsyncPublishingDispatcher
     {
-        return new AsyncPublishingDispatcher(
-            new WPDBQueueRepository(Database::get()),
-            new PublisherSelector(
-                new PublisherRepository(),
-                new PublisherTargetProvider(new WordpressSettingsRepository()),
-                new PublisherFactory(),
-                LoggerFactory::create()
-            ),
-            new ArticleFactory(new WpPostContentRenderer())
-        );
+        return self::container()->get(AsyncPublishingDispatcher::class);
     }
 
 }

--- a/src/Infrastructure/DI/ContainerProvider.php
+++ b/src/Infrastructure/DI/ContainerProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Infrastructure\DI;
+
+use DI\Container;
+use DI\ContainerBuilder;
+
+final class ContainerProvider
+{
+    private static ?Container $container = null;
+
+    public static function getContainer(): Container
+    {
+        if (self::$container === null) {
+            $builder = new ContainerBuilder();
+            $builder->addDefinitions(dirname(__DIR__, 3) . '/config/di.php');
+            self::$container = $builder->build();
+        }
+
+        return self::$container;
+    }
+}


### PR DESCRIPTION
## Summary
- move `ContainerProvider` to generic Infrastructure namespace
- integrate container into `WordpressCron`
- update plugin to use new provider

## Testing
- `php -l src/Infrastructure/DI/ContainerProvider.php`
- `php -l src/Adapter/WordpressPlugin.php`
- `php -l src/Adapter/WordpressCron.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a695dbfac832999c1a9936ba05fcb