### PR TITLE
Refactor WordPress wiring for DI

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -27,6 +27,11 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Factory\ArticleFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressFilterDispatcher;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookDispatcher;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
+use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
+use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WPDBQueueRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
@@ -54,5 +59,8 @@ return [
     ReleaseProviderInterface::class => autowire(ReleaseService::class),
     FilterDispatcherInterface::class => create(WordpressFilterDispatcher::class),
     HookDispatcherInterface::class => create(WordpressHookDispatcher::class),
+    SettingsSaveHandler::class => autowire(SettingsSaveHandler::class),
+    SettingsPageRegistrar::class => autowire(SettingsPageRegistrar::class),
+    MetaBox::class => autowire(MetaBox::class),
     LoggerInterface::class => factory([LoggerFactory::class, 'create']),
 ];

--- a/config/di.php
+++ b/config/di.php
@@ -34,6 +34,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
 use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
+use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WPDBQueueRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
@@ -66,5 +67,6 @@ return [
     MetaBox::class => autowire(MetaBox::class),
     OAuthTokenProviderFactory::class => autowire(OAuthTokenProviderFactory::class),
     OAuthController::class => autowire(OAuthController::class),
+    PluginUpdateManager::class => autowire(PluginUpdateManager::class),
     LoggerInterface::class => factory([LoggerFactory::class, 'create']),
 ];

--- a/config/di.php
+++ b/config/di.php
@@ -30,6 +30,8 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
@@ -62,5 +64,7 @@ return [
     SettingsSaveHandler::class => autowire(SettingsSaveHandler::class),
     SettingsPageRegistrar::class => autowire(SettingsPageRegistrar::class),
     MetaBox::class => autowire(MetaBox::class),
+    OAuthTokenProviderFactory::class => autowire(OAuthTokenProviderFactory::class),
+    OAuthController::class => autowire(OAuthController::class),
     LoggerInterface::class => factory([LoggerFactory::class, 'create']),
 ];

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -9,6 +9,9 @@ use N3XT0R\XPub\Application\Service\Queue\AsyncPublishingDispatcher;
 use N3XT0R\XPub\Infrastructure\Wordpress\Factory\ArticleFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Presentation\AdminNoticePresenter;
 use N3XT0R\XPub\Infrastructure\Wordpress\Service\Plugin\PluginBootstrapService;
@@ -48,8 +51,15 @@ final class WordpressPlugin
             self::container()->get(FilterDispatcherInterface::class)
         );
         $registrar = new WordpressHookRegistrar(
-            new HookProvider($pluginFile),
-            self::container()->get(HookDispatcherInterface::class)
+            new HookProvider(
+                $pluginFile,
+                self::container()->get(SettingsSaveHandler::class)
+            ),
+            self::container()->get(HookDispatcherInterface::class),
+            [
+                self::container()->get(SettingsPageRegistrar::class),
+                self::container()->get(MetaBox::class),
+            ]
         );
         $registrar->register($pluginFile);
     }

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -12,6 +12,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Presentation\AdminNoticePresenter;
 use N3XT0R\XPub\Infrastructure\Wordpress\Service\Plugin\PluginBootstrapService;
@@ -53,7 +54,8 @@ final class WordpressPlugin
         $registrar = new WordpressHookRegistrar(
             new HookProvider(
                 $pluginFile,
-                self::container()->get(SettingsSaveHandler::class)
+                self::container()->get(SettingsSaveHandler::class),
+                self::container()->get(\N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController::class),
             ),
             self::container()->get(HookDispatcherInterface::class),
             [

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -13,6 +13,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Presentation\AdminNoticePresenter;
 use N3XT0R\XPub\Infrastructure\Wordpress\Service\Plugin\PluginBootstrapService;
@@ -51,12 +52,20 @@ final class WordpressPlugin
         PublisherFactory::setFilterDispatcher(
             self::container()->get(FilterDispatcherInterface::class)
         );
+        $updateManager = self::container()->make(PluginUpdateManager::class, [
+            'pluginFile' => plugin_basename($pluginFile),
+            'pluginSlug' => 'xpub-multi-channel-publisher',
+            'pluginInfoUrl' => 'https://github.com/N3XT0R/WP-XPub',
+        ]);
+
+        $hookProvider = self::container()->make(HookProvider::class, [
+            'saveHandler' => self::container()->get(SettingsSaveHandler::class),
+            'oauthController' => self::container()->get(OAuthController::class),
+            'updateManager' => $updateManager,
+        ]);
+
         $registrar = new WordpressHookRegistrar(
-            new HookProvider(
-                $pluginFile,
-                self::container()->get(SettingsSaveHandler::class),
-                self::container()->get(\N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController::class),
-            ),
+            $hookProvider,
             self::container()->get(HookDispatcherInterface::class),
             [
                 self::container()->get(SettingsPageRegistrar::class),

--- a/src/Infrastructure/OAuth/OAuthTokenProviderFactory.php
+++ b/src/Infrastructure/OAuth/OAuthTokenProviderFactory.php
@@ -15,30 +15,40 @@ use RuntimeException;
 
 final class OAuthTokenProviderFactory
 {
-    protected static array $defaultProviderMap = [
-        'mastodon' => \N3XT0R\XPub\Infrastructure\OAuth\Provider\MastodonOAuthTokenProvider::class,
-    ];
+    /**
+     * @param array<string, class-string<OAuthTokenProviderInterface>> $providerMap
+     */
+    public function __construct(
+        private PublisherRepository $repository,
+        private WordpressSettingsRepository $settingsRepo,
+        private array $providerMap = [
+            'mastodon' => \N3XT0R\XPub\Infrastructure\OAuth\Provider\MastodonOAuthTokenProvider::class,
+        ],
+    ) {
+    }
 
-    public static function createFromPublisherSlug(string $slug): OAuthTokenProviderInterface
+    public function createFromPublisherSlug(string $slug): OAuthTokenProviderInterface
     {
-        $repository = new PublisherRepository();
-        $publisher = $repository->findBySlug($slug, PurposeType::OAUTH);
+        $publisher = $this->repository->findBySlug($slug, PurposeType::OAUTH);
 
         if (!$publisher) {
             throw new RuntimeException("Publisher '$slug' not found");
         }
 
-        return self::create($slug, $publisher->getConfigArray());
+        return $this->create($slug, $publisher->getConfigArray());
     }
 
-    protected static function getProviderMap(): array
+    /**
+     * @return array<string, class-string<OAuthTokenProviderInterface>>
+     */
+    private function getProviderMap(): array
     {
-        return apply_filters('wp_xpub_oauth_provider_map', self::$defaultProviderMap);
+        return apply_filters('wp_xpub_oauth_provider_map', $this->providerMap);
     }
 
-    public static function create(string $slug, array $config): OAuthTokenProviderInterface
+    public function create(string $slug, array $config): OAuthTokenProviderInterface
     {
-        $map = self::getProviderMap();
+        $map = $this->getProviderMap();
 
         if (!isset($map[$slug]) || !class_exists($map[$slug])) {
             throw new RuntimeException("No OAuthTokenProvider found for slug '$slug'");
@@ -55,7 +65,7 @@ final class OAuthTokenProviderFactory
 
         return new $class(
             new GenericProvider($providerConfig),
-            new WordpressSettingsRepository(),
+            $this->settingsRepo,
             $grantType
         );
     }

--- a/src/Infrastructure/Wordpress/Admin/SettingsPageRegistrar.php
+++ b/src/Infrastructure/Wordpress/Admin/SettingsPageRegistrar.php
@@ -6,38 +6,35 @@ namespace N3XT0R\XPub\Infrastructure\Wordpress\Admin;
 
 use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookRegistrableInterface;
-use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
-use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
 
 final class SettingsPageRegistrar implements HookRegistrableInterface
 {
+    public function __construct(private PublisherSettingsService $service)
+    {
+    }
+
     public function register(): void
     {
         add_action('admin_menu', [$this, 'addOptionsPage']);
     }
 
-
-    public static function addOptionsPage(): void
+    public function addOptionsPage(): void
     {
         add_options_page(
-            'XPUB Einstellungen',      // Page title
-            'XPUB',                    // Menu title
-            'manage_options',          // Capability
-            'xpub-settings',           // Menu slug
-            [self::class, 'renderSettingsPage'] // Callback to render content
+            'XPUB Einstellungen',
+            'XPUB',
+            'manage_options',
+            'xpub-settings',
+            [$this, 'renderSettingsPage']
         );
     }
 
-    public static function renderSettingsPage(): void
+    public function renderSettingsPage(): void
     {
-        $service = new PublisherSettingsService(
-            new PublisherRepository(),
-            new WordpressSettingsRepository()
-        );
         View::render('layouts.admin', [
             'title' => 'XPUB Einstellungen',
-            'content' => fn() => View::render('admin.settings-page', $service->getSettingsViewData()),
+            'content' => fn() => View::render('admin.settings-page', $this->service->getSettingsViewData()),
         ]);
     }
 }

--- a/src/Infrastructure/Wordpress/Admin/SettingsSaveHandler.php
+++ b/src/Infrastructure/Wordpress/Admin/SettingsSaveHandler.php
@@ -10,17 +10,23 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 
 final class SettingsSaveHandler
 {
+    public function __construct(
+        private SettingsFormRequestValidator $validator,
+        private WordpressSettingsRepository $settingsRepo,
+        private PublisherRepository $publisherRepo,
+    ) {
+    }
+
     public function handle(): void
     {
-        (new SettingsFormRequestValidator())->validate();
+        $this->validator->validate();
 
         $activePublisherSlugs = isset($_POST['active_publishers']) ? wp_unslash($_POST['active_publishers']) : [];
         $activePublisherSlugs = array_map('sanitize_text_field', $activePublisherSlugs);
 
         $publisherConfigs = isset($_POST['config']) ? wp_unslash($_POST['config']) : [];
 
-        $settingsRepo = new WordpressSettingsRepository();
-        $settingsRepo->set('xpub_publisher_targets', $activePublisherSlugs);
+        $this->settingsRepo->set('xpub_publisher_targets', $activePublisherSlugs);
 
         $this->persistPublisherConfigs($publisherConfigs);
 
@@ -31,14 +37,12 @@ final class SettingsSaveHandler
 
     private function persistPublisherConfigs(array $publisherConfigs): void
     {
-        $repository = new PublisherRepository();
-
         foreach ($publisherConfigs as $slug => $configs) {
             if (!is_array($configs) || empty($slug)) {
                 continue;
             }
 
-            $repository->updateConfig($slug, $configs);
+            $this->publisherRepo->updateConfig($slug, $configs);
         }
     }
 }

--- a/src/Infrastructure/Wordpress/Hook/HookProvider.php
+++ b/src/Infrastructure/Wordpress/Hook/HookProvider.php
@@ -14,6 +14,7 @@ final class HookProvider
     public function __construct(
         private readonly string $pluginFile,
         private readonly SettingsSaveHandler $saveHandler,
+        private readonly OAuthController $oauthController,
     ) {
     }
 
@@ -29,7 +30,7 @@ final class HookProvider
             new HookDefinition('publish_post', [WordpressPlugin::class, 'handlePublishFromPost'], 10, 2),
             new HookDefinition('admin_post_xpub_save_settings', fn() => $this->saveHandler->handle()),
             new HookDefinition('init', fn() => PluginUpdateManager::boot($this->pluginFile)),
-            new HookDefinition('rest_api_init', [OAuthController::class, 'register']),
+            new HookDefinition('rest_api_init', [$this->oauthController, 'register']),
         ];
     }
 }

--- a/src/Infrastructure/Wordpress/Hook/HookProvider.php
+++ b/src/Infrastructure/Wordpress/Hook/HookProvider.php
@@ -12,9 +12,9 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 final class HookProvider
 {
     public function __construct(
-        private readonly string $pluginFile,
         private readonly SettingsSaveHandler $saveHandler,
         private readonly OAuthController $oauthController,
+        private readonly PluginUpdateManager $updateManager,
     ) {
     }
 
@@ -29,7 +29,7 @@ final class HookProvider
             new HookDefinition('save_post', [WordpressPlugin::class, 'handleSaveFromPost'], 10, 2),
             new HookDefinition('publish_post', [WordpressPlugin::class, 'handlePublishFromPost'], 10, 2),
             new HookDefinition('admin_post_xpub_save_settings', fn() => $this->saveHandler->handle()),
-            new HookDefinition('init', fn() => PluginUpdateManager::boot($this->pluginFile)),
+            new HookDefinition('init', fn() => $this->updateManager->register()),
             new HookDefinition('rest_api_init', [$this->oauthController, 'register']),
         ];
     }

--- a/src/Infrastructure/Wordpress/Hook/HookProvider.php
+++ b/src/Infrastructure/Wordpress/Hook/HookProvider.php
@@ -11,9 +11,10 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 
 final class HookProvider
 {
-
-    public function __construct(private readonly string $pluginFile)
-    {
+    public function __construct(
+        private readonly string $pluginFile,
+        private readonly SettingsSaveHandler $saveHandler,
+    ) {
     }
 
     /**
@@ -26,9 +27,7 @@ final class HookProvider
             new HookDefinition('admin_notices', [WordpressPlugin::class, 'showAdminNotice']),
             new HookDefinition('save_post', [WordpressPlugin::class, 'handleSaveFromPost'], 10, 2),
             new HookDefinition('publish_post', [WordpressPlugin::class, 'handlePublishFromPost'], 10, 2),
-            new HookDefinition('admin_post_xpub_save_settings', function () {
-                (new SettingsSaveHandler())->handle();
-            }),
+            new HookDefinition('admin_post_xpub_save_settings', fn() => $this->saveHandler->handle()),
             new HookDefinition('init', fn() => PluginUpdateManager::boot($this->pluginFile)),
             new HookDefinition('rest_api_init', [OAuthController::class, 'register']),
         ];

--- a/src/Infrastructure/Wordpress/Hook/WordpressHookRegistrar.php
+++ b/src/Infrastructure/Wordpress/Hook/WordpressHookRegistrar.php
@@ -7,15 +7,19 @@ namespace N3XT0R\XPub\Infrastructure\Wordpress\Hook;
 use N3XT0R\XPub\Adapter\WordpressCron;
 use N3XT0R\XPub\Adapter\WordpressPlugin;
 use N3XT0R\XPub\Domain\Hook\HookDispatcherInterface;
-use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
-use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
+use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookRegistrableInterface;
 
 final readonly class WordpressHookRegistrar
 {
+    /** @var HookRegistrableInterface[] */
+    private array $adminRegistrables;
+
     public function __construct(
         private HookProvider $provider,
-        private HookDispatcherInterface $dispatcher = new WordpressHookDispatcher()
+        private HookDispatcherInterface $dispatcher,
+        array $adminRegistrables = []
     ) {
+        $this->adminRegistrables = $adminRegistrables;
     }
 
     public function register(string $pluginFile): void
@@ -44,15 +48,8 @@ final readonly class WordpressHookRegistrar
 
     private function registerAdminRegistrables(): void
     {
-        $registrables = [
-            new SettingsPageRegistrar(),
-            new MetaBox(),
-        ];
-
-        foreach ($registrables as $registrable) {
-            if ($registrable instanceof HookRegistrableInterface) {
-                $registrable->register();
-            }
+        foreach ($this->adminRegistrables as $registrable) {
+            $registrable->register();
         }
     }
 }

--- a/src/Infrastructure/Wordpress/Rest/OAuthController.php
+++ b/src/Infrastructure/Wordpress/Rest/OAuthController.php
@@ -11,33 +11,37 @@ use WP_REST_Response;
 
 class OAuthController
 {
-    public static function register(): void
+    public function __construct(private OAuthTokenProviderFactory $factory)
+    {
+    }
+
+    public function register(): void
     {
         register_rest_route('xpub/v1', '/oauth/(?P<provider>[a-z0-9_-]+)/start', [
             'methods' => 'GET',
-            'callback' => [self::class, 'start'],
+            'callback' => [$this, 'start'],
             'permission_callback' => '__return_true',
         ]);
 
         register_rest_route('xpub/v1', '/oauth/(?P<provider>[a-z0-9_-]+)/callback', [
             'methods' => 'GET',
-            'callback' => [self::class, 'callback'],
+            'callback' => [$this, 'callback'],
             'permission_callback' => '__return_true',
         ]);
 
         register_rest_route('xpub/v1', '/oauth/(?P<provider>[a-z0-9_-]+)/client-token', [
             'methods' => 'POST',
-            'callback' => [self::class, 'clientCredentialsToken'],
+            'callback' => [$this, 'clientCredentialsToken'],
             'permission_callback' => '__return_true',
         ]);
     }
 
-    public static function start(WP_REST_Request $request): WP_REST_Response|WP_Error
+    public function start(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         $slug = $request->get_param('provider');
 
         try {
-            $provider = OAuthTokenProviderFactory::createFromPublisherSlug($slug);
+            $provider = $this->factory->createFromPublisherSlug($slug);
             $authUrl = $provider->getAuthorizationUrl();
             update_option("xpub_oauth_{$slug}_state", $provider->getState());
 
@@ -47,7 +51,7 @@ class OAuthController
         }
     }
 
-    public static function callback(WP_REST_Request $request): WP_REST_Response|WP_Error
+    public function callback(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         $slug = $request->get_param('provider');
         $expectedState = get_option("xpub_oauth_{$slug}_state");
@@ -57,7 +61,7 @@ class OAuthController
         }
 
         try {
-            $provider = OAuthTokenProviderFactory::createFromPublisherSlug($slug);
+            $provider = $this->factory->createFromPublisherSlug($slug);
             $accessToken = $provider->fetchAccessTokenByCode($request->get_param('code'));
             $provider->storeAccessToken($accessToken);
 
@@ -67,12 +71,12 @@ class OAuthController
         }
     }
 
-    public static function clientCredentialsToken(WP_REST_Request $request): WP_REST_Response|WP_Error
+    public function clientCredentialsToken(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         $slug = $request->get_param('provider');
 
         try {
-            $provider = OAuthTokenProviderFactory::createFromPublisherSlug($slug);
+            $provider = $this->factory->createFromPublisherSlug($slug);
             $accessToken = $provider->fetchAccessTokenByClientCredentials();
 
             return new WP_REST_Response([

--- a/src/Infrastructure/Wordpress/Updater/PluginUpdateManager.php
+++ b/src/Infrastructure/Wordpress/Updater/PluginUpdateManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Infrastructure\Wordpress\Updater;
 
-use N3XT0R\XPub\Application\Update\ReleaseService;
+use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
 use N3XT0R\XPub\Domain\Contracts\ReleaseProviderInterface;
 
 use function get_plugin_data;
@@ -19,22 +19,22 @@ class PluginUpdateManager
     public function __construct(
         string $pluginFile,
         string $pluginSlug,
-        string $pluginInfoUrl = '',
-        ?ReleaseProviderInterface $releaseService = null
+        string $pluginInfoUrl,
+        ReleaseProviderInterface $releaseService,
     ) {
         $this->pluginFile = $pluginFile;
         $this->pluginSlug = $pluginSlug;
         $this->pluginInfoUrl = $pluginInfoUrl;
-        $this->releaseService = $releaseService ?? new ReleaseService();
+        $this->releaseService = $releaseService;
     }
 
     public static function boot(string $pluginFile): void
     {
-        (new self(
-            plugin_basename($pluginFile),
-            'xpub-multi-channel-publisher',
-            'https://github.com/N3XT0R/WP-XPub'
-        ))->register();
+        ContainerProvider::getContainer()->make(self::class, [
+            'pluginFile' => plugin_basename($pluginFile),
+            'pluginSlug' => 'xpub-multi-channel-publisher',
+            'pluginInfoUrl' => 'https://github.com/N3XT0R/WP-XPub',
+        ])->register();
     }
 
     public function register(): void

--- a/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
@@ -6,6 +6,10 @@ namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Hook;
 
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookDefinition;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
+use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
+use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use PHPUnit\Framework\TestCase;
 
 class HookProviderTest extends TestCase
@@ -13,7 +17,14 @@ class HookProviderTest extends TestCase
     public function testItProvidesExpectedHooks(): void
     {
         $dummyPluginFile = 'my-plugin/my-plugin.php';
-        $provider = new HookProvider($dummyPluginFile);
+        $provider = new HookProvider(
+            $dummyPluginFile,
+            new SettingsSaveHandler(
+                new SettingsFormRequestValidator(),
+                new WordpressSettingsRepository(),
+                new PublisherRepository(),
+            )
+        );
         $hooks = $provider->getHooks();
 
         $this->assertIsArray($hooks);

--- a/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
@@ -7,6 +7,8 @@ namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Hook;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookDefinition;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
@@ -23,6 +25,12 @@ class HookProviderTest extends TestCase
                 new SettingsFormRequestValidator(),
                 new WordpressSettingsRepository(),
                 new PublisherRepository(),
+            ),
+            new OAuthController(
+                new OAuthTokenProviderFactory(
+                    new PublisherRepository(),
+                    new WordpressSettingsRepository(),
+                )
             )
         );
         $hooks = $provider->getHooks();

--- a/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
@@ -9,6 +9,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
 use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
@@ -18,9 +19,7 @@ class HookProviderTest extends TestCase
 {
     public function testItProvidesExpectedHooks(): void
     {
-        $dummyPluginFile = 'my-plugin/my-plugin.php';
         $provider = new HookProvider(
-            $dummyPluginFile,
             new SettingsSaveHandler(
                 new SettingsFormRequestValidator(),
                 new WordpressSettingsRepository(),
@@ -31,6 +30,12 @@ class HookProviderTest extends TestCase
                     new PublisherRepository(),
                     new WordpressSettingsRepository(),
                 )
+            ),
+            new PluginUpdateManager(
+                'plugin.php',
+                'xpub-multi-channel-publisher',
+                'https://example.com',
+                new \N3XT0R\XPub\Application\Update\ReleaseService()
             )
         );
         $hooks = $provider->getHooks();

--- a/tests/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
@@ -9,6 +9,8 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
@@ -26,6 +28,12 @@ final class WordpressHookRegistrarTest extends TestCase
                 new SettingsFormRequestValidator(),
                 new WordpressSettingsRepository(),
                 new PublisherRepository(),
+            ),
+            new OAuthController(
+                new OAuthTokenProviderFactory(
+                    new PublisherRepository(),
+                    new WordpressSettingsRepository(),
+                )
             )
         );
         $dispatcher = new DummyDispatcher();

--- a/tests/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
@@ -11,6 +11,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
 use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
+use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
@@ -21,9 +22,7 @@ final class WordpressHookRegistrarTest extends TestCase
 {
     public function testItDispatchesAllHooksFromProvider(): void
     {
-        $dummyPluginFile = 'my-plugin/my-plugin.php';
         $provider = new HookProvider(
-            $dummyPluginFile,
             new SettingsSaveHandler(
                 new SettingsFormRequestValidator(),
                 new WordpressSettingsRepository(),
@@ -34,6 +33,12 @@ final class WordpressHookRegistrarTest extends TestCase
                     new PublisherRepository(),
                     new WordpressSettingsRepository(),
                 )
+            ),
+            new PluginUpdateManager(
+                'plugin.php',
+                'xpub-multi-channel-publisher',
+                'https://example.com',
+                new \N3XT0R\XPub\Application\Update\ReleaseService()
             )
         );
         $dispatcher = new DummyDispatcher();

--- a/tests/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
@@ -6,6 +6,12 @@ namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Hook;
 
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
+use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
+use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
+use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Tests\Stubs\DummyDispatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -14,9 +20,16 @@ final class WordpressHookRegistrarTest extends TestCase
     public function testItDispatchesAllHooksFromProvider(): void
     {
         $dummyPluginFile = 'my-plugin/my-plugin.php';
-        $provider = new HookProvider($dummyPluginFile);
+        $provider = new HookProvider(
+            $dummyPluginFile,
+            new SettingsSaveHandler(
+                new SettingsFormRequestValidator(),
+                new WordpressSettingsRepository(),
+                new PublisherRepository(),
+            )
+        );
         $dispatcher = new DummyDispatcher();
-        $registrar = new WordpressHookRegistrar($provider, $dispatcher);
+        $registrar = new WordpressHookRegistrar($provider, $dispatcher, []);
 
         $reflection = new \ReflectionClass($registrar);
         $method = $reflection->getMethod('registerActions');


### PR DESCRIPTION
## Summary
- inject admin components into `WordpressHookRegistrar`
- inject `SettingsSaveHandler` into `HookProvider`
- refactor `SettingsPageRegistrar` and `SettingsSaveHandler` for DI
- wire dependencies in DI container
- update plugin bootstrap to supply new dependencies
- adjust unit tests

## Testing
- `php -l src/Infrastructure/Wordpress/Hook/HookProvider.php`
- `php -l src/Infrastructure/Wordpress/Hook/WordpressHookRegistrar.php`
- `php -l src/Infrastructure/Wordpress/Admin/SettingsPageRegistrar.php`
- `php -l src/Infrastructure/Wordpress/Admin/SettingsSaveHandler.php`
- `php -l src/Adapter/WordpressPlugin.php`
- `php -l tests/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php`
- `php -l tests/Infrastructure/Wordpress/Hook/HookProviderTest.php`
- `find src -name '*.php' | xargs -I{} php -l {}`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a712af830832982611743f5898975