### PR TITLE
Refactor publisher factory to use DI container

### DIFF
--- a/src/Application/Factory/PublisherFactory.php
+++ b/src/Application/Factory/PublisherFactory.php
@@ -11,6 +11,7 @@ use N3XT0R\XPub\Domain\Contracts\SlugAwareInterface;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
 use N3XT0R\XPub\Infrastructure\Publishers\DevToPublisher;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
+use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
 use RuntimeException;
 
 final class PublisherFactory
@@ -77,7 +78,7 @@ final class PublisherFactory
 
     private static function instantiatePublisher(string $slug, string $class, array $config = []): PublisherInterface
     {
-        $instance = new $class();
+        $instance = ContainerProvider::getContainer()->get($class);
 
         if (!$instance instanceof PublisherInterface) {
             throw new RuntimeException("Class '$class' must implement PublisherInterface");


### PR DESCRIPTION
## Summary
- use the DI container inside `PublisherFactory`
- allow publishers to be resolved via the container

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a88bca2448329b7482ad4cfbab4c1