### PR TITLE
Refactor to isolate layers

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -18,6 +18,7 @@ use N3XT0R\XPub\Domain\Contracts\ViewInterface;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
 use N3XT0R\XPub\Domain\Hook\HookDispatcherInterface;
 use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Domain\Repository\PostStatusRepositoryInterface;
 use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
 use N3XT0R\XPub\Domain\Contracts\QueueRepositoryInterface;
 use N3XT0R\XPub\Infrastructure\Markdown\HtmlToMarkdownRendererFactory;
@@ -36,6 +37,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
+use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WpPostStatusRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WPDBQueueRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
@@ -47,6 +49,7 @@ return [
     SettingsRepositoryInterface::class => autowire(WordpressSettingsRepository::class),
     PublisherRepositoryInterface::class => autowire(PublisherRepository::class),
     QueueRepositoryInterface::class => factory(fn () => new WPDBQueueRepository(Database::get())),
+    PostStatusRepositoryInterface::class => autowire(WpPostStatusRepository::class),
 
     // Factories and helpers
     ArticleFactoryInterface::class => autowire(ArticleFactory::class),

--- a/src/Adapter/WordpressCron.php
+++ b/src/Adapter/WordpressCron.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace N3XT0R\XPub\Adapter;
 
 use DI\Container;
-use N3XT0R\XPub\Application\Factory\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Application\Service\Queue\JobRunner;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
 use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Adapter;
 
-use N3XT0R\XPub\Application\Factory\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Application\Service\Queue\AsyncPublishingDispatcher;
 use N3XT0R\XPub\Infrastructure\Wordpress\Factory\ArticleFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;

--- a/src/Application/Publisher/PublisherSelector.php
+++ b/src/Application/Publisher/PublisherSelector.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Application\Publisher;
 
-use N3XT0R\XPub\Application\Factory\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
 use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
 use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;

--- a/src/Application/Service/Queue/JobRunner.php
+++ b/src/Application/Service/Queue/JobRunner.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use N3XT0R\XPub\Application\Publisher\PublisherSelector;
 use N3XT0R\XPub\Domain\Contracts\Factory\ArticleFactoryInterface;
 use N3XT0R\XPub\Domain\Contracts\QueueRepositoryInterface;
+use N3XT0R\XPub\Domain\Repository\PostStatusRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
 class JobRunner
@@ -16,6 +17,7 @@ class JobRunner
         private readonly QueueRepositoryInterface $queue,
         private readonly PublisherSelector $publisherSelector,
         private readonly ArticleFactoryInterface $articleFactory,
+        private readonly PostStatusRepositoryInterface $postStatusRepository,
         private readonly ?LoggerInterface $logger = null
     ) {
     }
@@ -30,7 +32,7 @@ class JobRunner
                 $article = $this->articleFactory->fromArray($job->payload);
 
                 // Skip if article is not published
-                if (!$this->isPublishedAndNotOutdated($article->postId)) {
+                if (!$this->postStatusRepository->isPublishedAndNotOutdated($article->postId)) {
                     $this->logger?->info("Skipping job {$job->id} for unpublished post {$article->postId}");
                     continue;
                 }
@@ -49,38 +51,5 @@ class JobRunner
         }
     }
 
-    /**
-     * Checks whether a given WordPress post is published and has no newer unpublished revision.
-     *
-     * This ensures that only the latest published version is processed.
-     * If a newer revision exists (e.g. a draft or scheduled update), the method returns false.
-     *
-     * @param  int  $postId  The ID of the parent (published) post.
-     * @return bool True if the post is published and not outdated by a newer unpublished revision; false otherwise.
-     */
-    private function isPublishedAndNotOutdated(int $postId): bool
-    {
-        $post = get_post($postId);
-
-        if (!$post instanceof \WP_Post || $post->post_status !== 'publish') {
-            $this->logger?->debug("Post {$postId} is not published");
-            return false;
-        }
-
-        $revisions = wp_get_post_revisions($postId);
-
-        foreach ($revisions as $rev) {
-            // Check if revision is newer and not published (i.e., still being edited)
-            if (
-                $rev->post_modified_gmt > $post->post_modified_gmt &&
-                $rev->post_status !== 'publish'
-            ) {
-                $this->logger?->debug("Post {$postId} has newer unpublished revision {$rev->ID}");
-                return false;
-            }
-        }
-
-        return true;
-    }
 
 }

--- a/src/Domain/Hook/HookDefinition.php
+++ b/src/Domain/Hook/HookDefinition.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Infrastructure\Wordpress\Hook;
+namespace N3XT0R\XPub\Domain\Hook;
 
 final readonly class HookDefinition
 {

--- a/src/Domain/Hook/HookDispatcherInterface.php
+++ b/src/Domain/Hook/HookDispatcherInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Domain\Hook;
 
-use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookDefinition;
+use N3XT0R\XPub\Domain\Hook\HookDefinition;
 
 interface HookDispatcherInterface
 {

--- a/src/Domain/Repository/PostStatusRepositoryInterface.php
+++ b/src/Domain/Repository/PostStatusRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Domain\Repository;
+
+interface PostStatusRepositoryInterface
+{
+    /**
+     * Determine if a post is published and has no newer unpublished revisions.
+     */
+    public function isPublishedAndNotOutdated(int $postId): bool;
+}

--- a/src/Domain/Service/ArticlePublisher.php
+++ b/src/Domain/Service/ArticlePublisher.php
@@ -4,8 +4,8 @@ namespace N3XT0R\XPub\Domain\Service;
 
 use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
 use N3XT0R\XPub\Domain\Entity\Article;
-use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class ArticlePublisher
 {
@@ -20,7 +20,7 @@ final class ArticlePublisher
     public function __construct(array $publishers, ?LoggerInterface $logger = null)
     {
         $this->publishers = $publishers;
-        $this->logger = $logger ?? LoggerFactory::create();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function publish(Article $article): void

--- a/src/Infrastructure/Publishers/PublisherFactory.php
+++ b/src/Infrastructure/Publishers/PublisherFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Application\Factory;
+namespace N3XT0R\XPub\Infrastructure\Publishers;
 
 use LogicException;
 use N3XT0R\XPub\Domain\Contracts\ConfigurablePublisherInterface;

--- a/src/Infrastructure/Wordpress/Factory/WordpressPublisherFactory.php
+++ b/src/Infrastructure/Wordpress/Factory/WordpressPublisherFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Infrastructure\Wordpress\Factory;
 
-use N3XT0R\XPub\Application\Factory\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Domain\Service\ArticlePublisher;
 use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;

--- a/src/Infrastructure/Wordpress/Hook/HookProvider.php
+++ b/src/Infrastructure/Wordpress/Hook/HookProvider.php
@@ -8,6 +8,7 @@ use N3XT0R\XPub\Adapter\WordpressPlugin;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
 use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
+use N3XT0R\XPub\Domain\Hook\HookDefinition;
 
 final class HookProvider
 {

--- a/src/Infrastructure/Wordpress/Hook/WordpressHookDispatcher.php
+++ b/src/Infrastructure/Wordpress/Hook/WordpressHookDispatcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace N3XT0R\XPub\Infrastructure\Wordpress\Hook;
 
 use N3XT0R\XPub\Domain\Hook\HookDispatcherInterface;
+use N3XT0R\XPub\Domain\Hook\HookDefinition;
 
 final class WordpressHookDispatcher implements HookDispatcherInterface
 {

--- a/src/Infrastructure/Wordpress/Repository/WpPostStatusRepository.php
+++ b/src/Infrastructure/Wordpress/Repository/WpPostStatusRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Repository;
+
+use N3XT0R\XPub\Domain\Repository\PostStatusRepositoryInterface;
+use WP_Post;
+
+final class WpPostStatusRepository implements PostStatusRepositoryInterface
+{
+    public function isPublishedAndNotOutdated(int $postId): bool
+    {
+        $post = get_post($postId);
+        if (!$post instanceof WP_Post || $post->post_status !== 'publish') {
+            return false;
+        }
+
+        $revisions = wp_get_post_revisions($postId);
+        foreach ($revisions as $rev) {
+            if (
+                $rev->post_modified_gmt > $post->post_modified_gmt &&
+                $rev->post_status !== 'publish'
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Application/Factory/PublisherFactoryTest.php
+++ b/tests/Application/Factory/PublisherFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace N3XT0R\XPub\Tests\Application\Factory;
 
-use N3XT0R\XPub\Application\Factory\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
 use N3XT0R\XPub\Infrastructure\Publishers\DevToPublisher;
 use PHPUnit\Framework\TestCase;

--- a/tests/Infrastructure/Wordpress/Factory/WordpressPublisherFactoryTest.php
+++ b/tests/Infrastructure/Wordpress/Factory/WordpressPublisherFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Factory;
 
-use N3XT0R\XPub\Application\Factory\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Domain\Entity\Publisher;
 use N3XT0R\XPub\Infrastructure\Wordpress\Factory\WordpressPublisherFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressFilterDispatcher;

--- a/tests/Infrastructure/Wordpress/Hook/HookDefinitionTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/HookDefinitionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Hook;
 
-use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookDefinition;
+use N3XT0R\XPub\Domain\Hook\HookDefinition;
 use PHPUnit\Framework\TestCase;
 
 class HookDefinitionTest extends TestCase

--- a/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
+++ b/tests/Infrastructure/Wordpress/Hook/HookProviderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Hook;
 
-use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookDefinition;
+use N3XT0R\XPub\Domain\Hook\HookDefinition;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;

--- a/tests/Stubs/DummyDispatcher.php
+++ b/tests/Stubs/DummyDispatcher.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace N3XT0R\XPub\Tests\Stubs;
 
 use N3XT0R\XPub\Domain\Hook\HookDispatcherInterface;
-use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookDefinition;
+use N3XT0R\XPub\Domain\Hook\HookDefinition;
 
 final class DummyDispatcher implements HookDispatcherInterface
 {


### PR DESCRIPTION
## Summary
- move publisher factory to infrastructure
- decouple logging from domain article publisher
- move hook definition into domain
- add post status repository for WordPress
- inject new repository into job runner
- wire new service in DI container

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a8a8da91c832992f55899e3f445a0