### PR TITLE
Remove infrastructure dependency from application services

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -43,6 +43,8 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
 use N3XT0R\XPub\Infrastructure\Wordpress\I18n\Translator;
 use Psr\Log\LoggerInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherFactoryInterface;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactoryService;
 
 return [
     // Core repositories and services
@@ -56,6 +58,7 @@ return [
     WordpressArticleFactoryInterface::class => get(ArticleFactory::class),
     RendersPostContentInterface::class => autowire(WpPostContentRenderer::class),
     HtmlToMarkdownRendererInterface::class => factory([HtmlToMarkdownRendererFactory::class, 'create']),
+    PublisherFactoryInterface::class => autowire(PublisherFactoryService::class),
 
     // Views & translations
     ViewInterface::class => create(View::class),

--- a/src/Application/Publisher/PublisherSelector.php
+++ b/src/Application/Publisher/PublisherSelector.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Application\Publisher;
 
-use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
+use N3XT0R\XPub\Domain\Contracts\PublisherFactoryInterface;
 use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
 use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
 use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
@@ -15,7 +15,7 @@ final readonly class PublisherSelector
     public function __construct(
         private PublisherRepositoryInterface $repository,
         private PublisherTargetProvider $provider,
-        private PublisherFactory $factory,
+        private PublisherFactoryInterface $factory,
         private ?LoggerInterface $logger = null
     ) {
     }

--- a/src/Domain/Contracts/PublisherFactoryInterface.php
+++ b/src/Domain/Contracts/PublisherFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Domain\Contracts;
+
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+
+interface PublisherFactoryInterface
+{
+    public function create(string $slug): PublisherInterface;
+
+    public function createWithConfig(string $slug, array $config): PublisherInterface;
+}
+

--- a/src/Infrastructure/Publishers/PublisherFactoryService.php
+++ b/src/Infrastructure/Publishers/PublisherFactoryService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Infrastructure\Publishers;
+
+use N3XT0R\XPub\Domain\Contracts\PublisherFactoryInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+
+final class PublisherFactoryService implements PublisherFactoryInterface
+{
+    public function create(string $slug): PublisherInterface
+    {
+        return PublisherFactory::create($slug);
+    }
+
+    public function createWithConfig(string $slug, array $config): PublisherInterface
+    {
+        return PublisherFactory::createWithConfig($slug, $config);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `PublisherFactoryInterface`
- implement `PublisherFactoryService` to delegate to existing factory
- inject the interface in `PublisherSelector`
- register the new service in the DI container

## Testing
- `vendor/bin/phpunit --display-warnings`

------
https://chatgpt.com/codex/tasks/task_e_688a8f51358c83299e74eeebc3302994