### PR TITLE
Add unit tests for OAuth and container utilities

### DIFF
--- a/tests/Application/Publisher/PublisherSelectorTest.php
+++ b/tests/Application/Publisher/PublisherSelectorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Application\Publisher;
+
+use N3XT0R\XPub\Application\Publisher\PublisherSelector;
+use N3XT0R\XPub\Domain\Contracts\PublisherFactoryInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class PublisherSelectorTest extends TestCase
+{
+    public function testGetReturnsPublisherInstance(): void
+    {
+        $publisherEntity = new Publisher('test', 'Test');
+        $repository = $this->createMock(PublisherRepositoryInterface::class);
+        $repository->method('findBySlug')->with('test')->willReturn($publisherEntity);
+
+        $factory = $this->createMock(PublisherFactoryInterface::class);
+        $publisherInstance = $this->createMock(PublisherInterface::class);
+        $factory->method('createWithConfig')->with('test', [])->willReturn($publisherInstance);
+
+        $settings = new class implements \N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface {
+            public function get(string $key, mixed $default = null): mixed { return []; }
+            public function set(string $key, mixed $value): bool { return true; }
+            public function delete(string $key): bool { return true; }
+        };
+        $targetProvider = new PublisherTargetProvider($settings);
+        $selector = new PublisherSelector($repository, $targetProvider, $factory, new NullLogger());
+        $this->assertSame($publisherInstance, $selector->get('test'));
+    }
+
+    public function testGetThrowsForMissingPublisher(): void
+    {
+        $repository = $this->createMock(PublisherRepositoryInterface::class);
+        $repository->method('findBySlug')->willReturn(null);
+
+        $settings = new class implements \N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface {
+            public function get(string $key, mixed $default = null): mixed { return []; }
+            public function set(string $key, mixed $value): bool { return true; }
+            public function delete(string $key): bool { return true; }
+        };
+        $targetProvider = new PublisherTargetProvider($settings);
+        $selector = new PublisherSelector($repository, $targetProvider, $this->createMock(PublisherFactoryInterface::class));
+        $this->expectException(\RuntimeException::class);
+        $selector->get('missing');
+    }
+
+    public function testGetActiveReturnsInstancesForTargets(): void
+    {
+        $publisherEntity = new Publisher('active', 'Active');
+        $repository = $this->createMock(PublisherRepositoryInterface::class);
+        $repository->method('findBySlug')->with('active')->willReturn($publisherEntity);
+        $repository->method('all')->willReturn([$publisherEntity]);
+
+        $settings = new class implements \N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface {
+            public function get(string $key, mixed $default = null): mixed { return ['active']; }
+            public function set(string $key, mixed $value): bool { return true; }
+            public function delete(string $key): bool { return true; }
+        };
+        $targetProvider = new PublisherTargetProvider($settings);
+
+        $factory = $this->createMock(PublisherFactoryInterface::class);
+        $publisherInstance = $this->createMock(PublisherInterface::class);
+        $factory->method('createWithConfig')->willReturn($publisherInstance);
+
+        $selector = new PublisherSelector($repository, $targetProvider, $factory, new NullLogger());
+        $result = $selector->getActive();
+        $this->assertArrayHasKey('active', $result);
+        $this->assertSame($publisherInstance, $result['active']);
+    }
+}

--- a/tests/Application/Update/ReleaseServiceTest.php
+++ b/tests/Application/Update/ReleaseServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace N3XT0R\XPub\Application\Update;
+function file_get_contents(string $filename, bool $use_include_path = false, $context = null)
+{
+    return \N3XT0R\XPub\Tests\Application\Update\ReleaseServiceTest::$content;
+}
+?>
+<?php
+namespace N3XT0R\XPub\Tests\Application\Update;
+
+use N3XT0R\XPub\Application\Update\ReleaseService;
+use PHPUnit\Framework\TestCase;
+
+class ReleaseServiceTest extends TestCase
+{
+    public static string $content = '';
+
+    public function testFetchLatestReleaseReturnsData(): void
+    {
+        self::$content = json_encode([
+            'tag_name' => 'v1.2.3',
+            'body' => 'changes',
+            'assets' => [['browser_download_url' => 'http://dl']]
+        ]);
+
+        $service = new ReleaseService();
+        $result = $service->fetchLatestRelease();
+        $this->assertSame('1.2.3', $result['version']);
+        $this->assertSame('changes', $result['changelog']);
+        $this->assertSame('http://dl', $result['download_url']);
+    }
+
+    public function testFetchLatestReleaseReturnsNullOnFailure(): void
+    {
+        self::$content = false;
+        $service = new ReleaseService();
+        $this->assertNull($service->fetchLatestRelease());
+    }
+}

--- a/tests/Domain/Config/DefaultPurposeTransformerTest.php
+++ b/tests/Domain/Config/DefaultPurposeTransformerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Domain\Config;
+
+use N3XT0R\XPub\Domain\Config\DefaultPurposeTransformer;
+use N3XT0R\XPub\Domain\Config\PurposeType;
+use PHPUnit\Framework\TestCase;
+
+class DefaultPurposeTransformerTest extends TestCase
+{
+    public function testSupportsReturnsTrueWhenNoGrantType(): void
+    {
+        $transformer = new DefaultPurposeTransformer();
+        $this->assertTrue($transformer->supports(['foo' => 'bar']));
+    }
+
+    public function testTransformAddsPurposeType(): void
+    {
+        $transformer = new DefaultPurposeTransformer();
+        $result = $transformer->transform(['key' => 'value']);
+        $this->assertSame(['key' => ['value' => 'value', 'purpose_type' => PurposeType::DEFAULT]], $result);
+    }
+}

--- a/tests/Domain/Config/GrantTypeResolverTest.php
+++ b/tests/Domain/Config/GrantTypeResolverTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Domain\Config;
+
+use N3XT0R\XPub\Infrastructure\OAuth\Support\GrantTypeResolver;
+use PHPUnit\Framework\TestCase;
+
+class GrantTypeResolverTest extends TestCase
+{
+    public function testResolveWithExplicitGrantType(): void
+    {
+        $config = ['grantType' => GrantTypeResolver::CLIENT_CREDENTIALS];
+        $this->assertSame(GrantTypeResolver::CLIENT_CREDENTIALS, GrantTypeResolver::resolve($config));
+    }
+
+    public function testResolveWithMissingRedirectUriDefaultsToClientCredentials(): void
+    {
+        $config = [
+            'urlAuthorize' => 'http://example.com',
+            'redirectUri' => '',
+        ];
+        $this->assertSame(GrantTypeResolver::CLIENT_CREDENTIALS, GrantTypeResolver::resolve($config));
+    }
+
+    public function testResolveFallbackToAuthorizationCode(): void
+    {
+        $config = [
+            'redirectUri' => 'http://example.com',
+            'urlAuthorize' => 'http://example.com',
+        ];
+        $this->assertSame(GrantTypeResolver::AUTHORIZATION_CODE, GrantTypeResolver::resolve($config));
+    }
+
+    public function testIsValid(): void
+    {
+        $this->assertTrue(GrantTypeResolver::isValid(GrantTypeResolver::CLIENT_CREDENTIALS));
+        $this->assertFalse(GrantTypeResolver::isValid('invalid'));
+    }
+}

--- a/tests/Domain/Config/OAuthGrantValidatorTest.php
+++ b/tests/Domain/Config/OAuthGrantValidatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Domain\Config;
+
+use N3XT0R\XPub\Domain\Config\oAuth\OAuthGrantValidator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class OAuthGrantValidatorTest extends TestCase
+{
+    public function testValidatePassesWithRequiredKeys(): void
+    {
+        $validator = new OAuthGrantValidator();
+        $config = [
+            'grant_type' => 'client_credentials',
+            'clientId' => 'id',
+            'clientSecret' => 'secret',
+            'urlAccessToken' => 'token',
+            'urlResourceOwnerDetails' => 'details',
+            'urlAuthorize' => 'auth',
+        ];
+        $validator->validate($config);
+        $this->assertTrue(true); // no exception
+    }
+
+    public function testValidateThrowsOnMissingKeys(): void
+    {
+        $validator = new OAuthGrantValidator();
+        $config = ['grant_type' => 'client_credentials'];
+        $this->expectException(InvalidArgumentException::class);
+        $validator->validate($config);
+    }
+
+    public function testUnsupportedGrantTypeThrows(): void
+    {
+        $validator = new OAuthGrantValidator();
+        $config = ['grant_type' => 'unsupported'];
+        $this->expectException(InvalidArgumentException::class);
+        $validator->validate($config);
+    }
+}

--- a/tests/Domain/Config/OAuthProviderConfigBuilderTest.php
+++ b/tests/Domain/Config/OAuthProviderConfigBuilderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Domain\Config;
+
+require_once __DIR__ . '/../../../src/Domain/Config/oAuth/OAuthProviderConfigBuilder.php';
+
+use N3XT0R\XPub\Domain\Config\OAuth\OAuthProviderConfigBuilder;
+use PHPUnit\Framework\TestCase;
+
+class OAuthProviderConfigBuilderTest extends TestCase
+{
+    public function testBuildAuthorizationCodeConfig(): void
+    {
+        $config = [
+            'clientId' => 'id',
+            'clientSecret' => 'secret',
+            'redirectUri' => 'http://example.com',
+            'urlAuthorize' => 'http://auth',
+            'urlAccessToken' => 'http://token',
+            'urlResourceOwnerDetails' => 'http://details',
+            'grant_type' => 'authorization_code',
+            'scopes' => 'read write'
+        ];
+        $result = OAuthProviderConfigBuilder::build($config);
+        $this->assertSame('id', $result['clientId']);
+        $this->assertSame(['read','write'], $result['scopes']);
+        $this->assertArrayHasKey('urlResourceOwnerDetails', $result);
+    }
+
+    public function testBuildClientCredentialsConfig(): void
+    {
+        $config = [
+            'clientId' => 'id',
+            'clientSecret' => 'secret',
+            'urlAuthorize' => 'http://auth',
+            'urlAccessToken' => 'http://token',
+            'urlResourceOwnerDetails' => 'http://details',
+            'grant_type' => 'client_credentials'
+        ];
+        $result = OAuthProviderConfigBuilder::build($config);
+        $this->assertArrayNotHasKey('redirectUri', $result);
+        $this->assertSame('http://details', $result['urlResourceOwnerDetails']);
+    }
+
+    public function testRequiredKeysForUnknownGrantTypeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        OAuthProviderConfigBuilder::requiredKeysForGrantType('invalid');
+    }
+}

--- a/tests/Domain/Config/OAuthPurposeTransformerTest.php
+++ b/tests/Domain/Config/OAuthPurposeTransformerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Domain\Config;
+
+use N3XT0R\XPub\Domain\Config\oAuth\OAuthPurposeTransformer;
+use N3XT0R\XPub\Domain\Config\PurposeType;
+use PHPUnit\Framework\TestCase;
+
+class OAuthPurposeTransformerTest extends TestCase
+{
+    public function testSupportsWhenGrantTypePresent(): void
+    {
+        $transformer = new OAuthPurposeTransformer();
+        $this->assertTrue($transformer->supports(['grant_type' => 'foo']));
+    }
+
+    public function testTransformAddsOAuthPurpose(): void
+    {
+        $transformer = new OAuthPurposeTransformer();
+        $result = $transformer->transform(['key' => 'value']);
+        $this->assertSame(['key' => ['value' => 'value', 'purpose_type' => PurposeType::OAUTH]], $result);
+    }
+}

--- a/tests/Infrastructure/DI/ContainerProviderTest.php
+++ b/tests/Infrastructure/DI/ContainerProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Infrastructure\DI;
+
+use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
+use PHPUnit\Framework\TestCase;
+use DI\Container;
+
+class ContainerProviderTest extends TestCase
+{
+    public function testReturnsSingletonContainer(): void
+    {
+        $c1 = ContainerProvider::getContainer();
+        $c2 = ContainerProvider::getContainer();
+        $this->assertInstanceOf(Container::class, $c1);
+        $this->assertSame($c1, $c2);
+    }
+}

--- a/tests/Infrastructure/OAuth/OAuthTokenProviderFactoryTest.php
+++ b/tests/Infrastructure/OAuth/OAuthTokenProviderFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace N3XT0R\XPub\Tests\Infrastructure\OAuth;
+
+use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
+use N3XT0R\XPub\Domain\Config\PurposeType;
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Infrastructure\OAuth\Provider\MastodonOAuthTokenProvider;
+use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
+use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
+use PHPUnit\Framework\TestCase;
+
+class OAuthTokenProviderFactoryTest extends TestCase
+{
+    public function testCreateFromPublisherSlugReturnsProvider(): void
+    {
+        $publisher = new Publisher('mastodon', 'Mastodon', [
+            new \N3XT0R\XPub\Domain\Entity\PublisherConfig('clientId', 'id'),
+            new \N3XT0R\XPub\Domain\Entity\PublisherConfig('clientSecret', 'secret'),
+            new \N3XT0R\XPub\Domain\Entity\PublisherConfig('urlAuthorize', 'a'),
+            new \N3XT0R\XPub\Domain\Entity\PublisherConfig('urlAccessToken', 't'),
+            new \N3XT0R\XPub\Domain\Entity\PublisherConfig('urlResourceOwnerDetails', 'd'),
+        ]);
+
+        $repository = $this->createMock(PublisherRepository::class);
+        $repository->method('findBySlug')->with('mastodon', PurposeType::OAUTH)->willReturn($publisher);
+        $settings = $this->createMock(WordpressSettingsRepository::class);
+
+        $factory = new OAuthTokenProviderFactory($repository, $settings);
+        $provider = $factory->createFromPublisherSlug('mastodon');
+        $this->assertInstanceOf(MastodonOAuthTokenProvider::class, $provider);
+    }
+
+    public function testCreateThrowsWhenProviderMissing(): void
+    {
+        $repository = $this->createMock(PublisherRepository::class);
+        $repository->method('findBySlug')->willReturn(null);
+        $settings = $this->createMock(WordpressSettingsRepository::class);
+
+        $factory = new OAuthTokenProviderFactory($repository, $settings);
+        $this->expectException(\RuntimeException::class);
+        $factory->createFromPublisherSlug('unknown');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -190,3 +190,8 @@ if (!class_exists('wpdb')) {
         }
     }
 }
+
+if (!class_exists('http\\Exception\\InvalidArgumentException')) {
+    class HttpInvalidArgumentException extends \InvalidArgumentException {}
+    class_alias(HttpInvalidArgumentException::class, 'http\\Exception\\InvalidArgumentException');
+}


### PR DESCRIPTION
## Summary
- add tests for OAuth config builders, validators and purpose transformers
- test OAuth provider factory and publisher selector logic
- add container provider and release service tests
- alias missing http exception for tests in bootstrap

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a919672388329b804c6b4fcb4bc86