### PR TITLE
Add unit tests for configs and publishers

### DIFF
--- a/tests/Unit/Application/Update/ReleaseServiceTest.php
+++ b/tests/Unit/Application/Update/ReleaseServiceTest.php
@@ -36,4 +36,11 @@ class ReleaseServiceTest extends TestCase
         $service = new ReleaseService();
         $this->assertNull($service->fetchLatestRelease());
     }
+
+    public function testFetchLatestReleaseReturnsNullForInvalidData(): void
+    {
+        self::$content = json_encode(['foo' => 'bar']);
+        $service = new ReleaseService();
+        $this->assertNull($service->fetchLatestRelease());
+    }
 }

--- a/tests/Unit/Domain/Config/PurposeTypeTest.php
+++ b/tests/Unit/Domain/Config/PurposeTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace N3XT0R\XPub\Tests\Domain\Config;
+
+use N3XT0R\XPub\Domain\Config\PurposeType;
+use PHPUnit\Framework\TestCase;
+
+class PurposeTypeTest extends TestCase
+{
+    public function testIsValid(): void
+    {
+        $this->assertTrue(PurposeType::isValid(PurposeType::DEFAULT));
+        $this->assertTrue(PurposeType::isValid(PurposeType::OAUTH));
+        $this->assertFalse(PurposeType::isValid('invalid'));
+    }
+
+    public function testAllReturnsAllTypes(): void
+    {
+        $this->assertSame([
+            PurposeType::DEFAULT,
+            PurposeType::OAUTH,
+        ], PurposeType::all());
+    }
+}

--- a/tests/Unit/Domain/Entity/PublisherConfigTest.php
+++ b/tests/Unit/Domain/Entity/PublisherConfigTest.php
@@ -13,4 +13,15 @@ class PublisherConfigTest extends TestCase
         $this->assertSame('api_key', $config->getKey());
         $this->assertSame('secret', $config->getValue());
     }
+
+    public function testPurposeTypeAndAsArray(): void
+    {
+        $config = new PublisherConfig('k', 'v', 'custom');
+        $this->assertSame('custom', $config->getPurposeType());
+        $this->assertSame([
+            'key' => 'k',
+            'value' => 'v',
+            'purpose_type' => 'custom',
+        ], $config->asArray());
+    }
 }

--- a/tests/Unit/Domain/Entity/PublisherTest.php
+++ b/tests/Unit/Domain/Entity/PublisherTest.php
@@ -18,4 +18,23 @@ class PublisherTest extends TestCase
         $this->assertSame(['api_key' => 'secret'], $publisher->getConfigArray());
         $this->assertSame('secret', $publisher->getConfigByKey('api_key'));
     }
+
+    public function testCategorizedConfigAndSetConfig(): void
+    {
+        $configs = [
+            new PublisherConfig('clientId', 'id', 'oauth'),
+            new PublisherConfig('api_key', 'secret', 'default'),
+        ];
+        $publisher = new Publisher('slug', 'Name', $configs);
+
+        $expected = [
+            'oauth' => ['clientId' => 'id'],
+            'default' => ['api_key' => 'secret'],
+        ];
+        $this->assertSame($expected, $publisher->getCategorizedConfigArray());
+
+        $new = [new PublisherConfig('n', 'v')];
+        $publisher->setConfig($new);
+        $this->assertSame($new, $publisher->getConfigs());
+    }
 }


### PR DESCRIPTION
## Summary
- test `PublisherConfig` purpose type and array conversion
- test `Publisher` categorized config behavior
- add `PurposeType` tests
- cover invalid data in `ReleaseService`

## Testing
- `./vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_688a9a10b1588329ac64d44b94601529