### PR TITLE
Add application and domain tests

### DIFF
--- a/tests/Integration/Application/Queue/JobRunnerIntegrationTest.php
+++ b/tests/Integration/Application/Queue/JobRunnerIntegrationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Integration\Application\Queue;
+
+use N3XT0R\XPub\Application\Factory\ArticleFactory;
+use N3XT0R\XPub\Application\Publisher\PublisherSelector;
+use N3XT0R\XPub\Application\Service\Queue\AsyncPublishingDispatcher;
+use N3XT0R\XPub\Application\Service\Queue\JobRunner;
+use N3XT0R\XPub\Domain\Contracts\PublisherFactoryInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Entity\Article;
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Domain\Repository\PostStatusRepositoryInterface;
+use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
+use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
+use N3XT0R\XPub\Tests\Stubs\InMemoryQueue;
+use N3XT0R\XPub\Tests\Stubs\SimplePublisher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class JobRunnerIntegrationTest extends TestCase
+{
+    private function createSelector(SimplePublisher $publisher): PublisherSelector
+    {
+        $entity = new Publisher('simple', 'Simple');
+        $repo = new class($entity) implements PublisherRepositoryInterface {
+            public function __construct(private Publisher $p) {}
+            public function all(): array { return [$this->p]; }
+            public function findBySlug(string $slug, ?string $purposeType = null): ?Publisher { return $this->p; }
+            public function updateConfig(string $slug, array $newConfig): bool { return true; }
+            public function create(string $slug, string $name, array $config): bool { return true; }
+        };
+        $settings = new class implements SettingsRepositoryInterface {
+            public function get(string $key, mixed $default = null): mixed { return ['simple']; }
+            public function set(string $key, mixed $value): bool { return true; }
+            public function delete(string $key): bool { return true; }
+        };
+        $provider = new PublisherTargetProvider($settings);
+        $factory = new class($publisher) implements PublisherFactoryInterface {
+            public function __construct(private PublisherInterface $p) {}
+            public function create(string $slug): PublisherInterface { return $this->p; }
+            public function createWithConfig(string $slug, array $config): PublisherInterface { return $this->p; }
+        };
+        return new PublisherSelector($repo, $provider, $factory, new NullLogger());
+    }
+
+    private function createRunner(SimplePublisher $publisher, InMemoryQueue $queue, bool $published): JobRunner
+    {
+        $selector = $this->createSelector($publisher);
+        $factory = new ArticleFactory();
+        $statusRepo = new class($published) implements PostStatusRepositoryInterface {
+            public function __construct(private bool $ok) {}
+            public function isPublishedAndNotOutdated(int $postId): bool { return $this->ok; }
+        };
+        return new JobRunner($queue, $selector, $factory, $statusRepo, new NullLogger());
+    }
+
+    private function dispatchArticle(AsyncPublishingDispatcher $dispatcher): Article
+    {
+        $article = new Article(1, 0, 'T', 'C', scheduledAt: new \DateTimeImmutable('2023-01-01'));
+        $dispatcher->dispatch($article);
+        return $article;
+    }
+
+    public function testRunPublishesAndMarksDone(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $selector = $this->createSelector($publisher);
+        $dispatcher = new AsyncPublishingDispatcher($queue, $selector, new ArticleFactory());
+        $this->dispatchArticle($dispatcher);
+
+        $runner = $this->createRunner($publisher, $queue, true);
+        $runner->run();
+
+        $this->assertCount(1, $publisher->published);
+        $this->assertCount(1, $queue->done);
+        $this->assertEmpty($queue->failed);
+    }
+
+    public function testRunSkipsUnpublishedArticle(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $selector = $this->createSelector($publisher);
+        $dispatcher = new AsyncPublishingDispatcher($queue, $selector, new ArticleFactory());
+        $this->dispatchArticle($dispatcher);
+
+        $runner = $this->createRunner($publisher, $queue, false);
+        $runner->run();
+
+        $this->assertEmpty($publisher->published);
+        $this->assertEmpty($queue->done);
+        $this->assertEmpty($queue->failed);
+    }
+
+    public function testRunMarksFailedOnException(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $publisher->shouldFail = true;
+        $selector = $this->createSelector($publisher);
+        $dispatcher = new AsyncPublishingDispatcher($queue, $selector, new ArticleFactory());
+        $this->dispatchArticle($dispatcher);
+
+        $runner = $this->createRunner($publisher, $queue, true);
+        $runner->run();
+
+        $this->assertCount(1, $queue->failed);
+        $this->assertEmpty($queue->done);
+    }
+}

--- a/tests/Integration/Domain/Entity/PublisherIntegrationTest.php
+++ b/tests/Integration/Domain/Entity/PublisherIntegrationTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Integration\Domain\Entity;
+
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Domain\Entity\PublisherConfig;
+use PHPUnit\Framework\TestCase;
+
+final class PublisherIntegrationTest extends TestCase
+{
+    public function testGetConfigByKeyReturnsNullWhenMissing(): void
+    {
+        $publisher = new Publisher('slug', 'Name', [new PublisherConfig('k', 'v')]);
+        $this->assertNull($publisher->getConfigByKey('missing'));
+    }
+}

--- a/tests/Stubs/InMemoryQueue.php
+++ b/tests/Stubs/InMemoryQueue.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Stubs;
+
+use DateTimeImmutable;
+use N3XT0R\XPub\Domain\Contracts\QueueRepositoryInterface;
+use N3XT0R\XPub\Domain\Entity\Job;
+
+final class InMemoryQueue implements QueueRepositoryInterface
+{
+    public array $jobs = [];
+    public array $done = [];
+    public array $failed = [];
+
+    public function enqueue(Job $job): bool
+    {
+        $this->jobs[] = $job;
+        return true;
+    }
+
+    public function getAllDueJobs(DateTimeImmutable $now): array
+    {
+        return $this->jobs;
+    }
+
+    public function markAsDone(Job $job): void
+    {
+        $this->done[] = $job;
+    }
+
+    public function markAsFailed(Job $job, string $errorMessage): void
+    {
+        $this->failed[] = [$job, $errorMessage];
+    }
+}

--- a/tests/Stubs/SimplePublisher.php
+++ b/tests/Stubs/SimplePublisher.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Stubs;
+
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Entity\Article;
+
+final class SimplePublisher implements PublisherInterface
+{
+    public array $published = [];
+    public bool $shouldFail = false;
+
+    public function publish(Article $article): bool
+    {
+        $this->published[] = $article;
+        if ($this->shouldFail) {
+            throw new \RuntimeException('fail');
+        }
+        return true;
+    }
+}

--- a/tests/Unit/Application/Factory/ArticleFactoryTest.php
+++ b/tests/Unit/Application/Factory/ArticleFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Application\Factory;
+
+use N3XT0R\XPub\Application\Factory\ArticleFactory;
+use N3XT0R\XPub\Domain\Entity\Article;
+use PHPUnit\Framework\TestCase;
+
+final class ArticleFactoryTest extends TestCase
+{
+    public function testFromArrayAndToArray(): void
+    {
+        $data = [
+            'postId' => 5,
+            'post_parent' => 0,
+            'title' => 'Title',
+            'content' => 'Body',
+            'excerpt' => 'ex',
+            'url' => 'http://url',
+            'htmlContent' => '<p>html</p>',
+            'tags' => ['t1', 't2'],
+            'scheduledAt' => new \DateTimeImmutable('2024-01-01 12:00:00'),
+        ];
+
+        $factory = new ArticleFactory();
+        $article = $factory->fromArray($data);
+
+        $this->assertInstanceOf(Article::class, $article);
+        $this->assertSame('Title', $article->title);
+        $this->assertSame('Body', $article->content);
+        $this->assertEquals($data['scheduledAt'], $article->scheduledAt);
+        $this->assertSame($data, $factory->toArray($article));
+    }
+
+    public function testMissingOptionalFields(): void
+    {
+        $data = [
+            'postId' => 9,
+            'title' => 'T',
+            'content' => 'C',
+            'scheduledAt' => null,
+        ];
+
+        $factory = new ArticleFactory();
+        $article = $factory->fromArray($data);
+
+        $array = $factory->toArray($article);
+        $this->assertSame(9, $array['postId']);
+        $this->assertNull($array['excerpt']);
+        $this->assertSame([], $array['tags']);
+    }
+}

--- a/tests/Unit/Application/Service/Queue/AsyncPublishingDispatcherTest.php
+++ b/tests/Unit/Application/Service/Queue/AsyncPublishingDispatcherTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Application\Service\Queue;
+
+use N3XT0R\XPub\Application\Factory\ArticleFactory;
+use N3XT0R\XPub\Application\Publisher\PublisherSelector;
+use N3XT0R\XPub\Application\Service\Queue\AsyncPublishingDispatcher;
+use N3XT0R\XPub\Domain\Contracts\PublisherFactoryInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Entity\Article;
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
+use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
+use N3XT0R\XPub\Tests\Stubs\InMemoryQueue;
+use N3XT0R\XPub\Tests\Stubs\SimplePublisher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class AsyncPublishingDispatcherTest extends TestCase
+{
+    private function createSelector(SimplePublisher $publisher): PublisherSelector
+    {
+        $publisherEntity = new Publisher('simple', 'Simple');
+
+        $repo = new class($publisherEntity) implements PublisherRepositoryInterface {
+            public function __construct(private Publisher $p) {}
+            public function all(): array { return [$this->p]; }
+            public function findBySlug(string $slug, ?string $purposeType = null): ?Publisher { return $this->p; }
+            public function updateConfig(string $slug, array $newConfig): bool { return true; }
+            public function create(string $slug, string $name, array $config): bool { return true; }
+        };
+
+        $settings = new class implements SettingsRepositoryInterface {
+            public function get(string $key, mixed $default = null): mixed { return ['simple']; }
+            public function set(string $key, mixed $value): bool { return true; }
+            public function delete(string $key): bool { return true; }
+        };
+
+        $provider = new PublisherTargetProvider($settings);
+
+        $factory = new class($publisher) implements PublisherFactoryInterface {
+            public function __construct(private PublisherInterface $p) {}
+            public function create(string $slug): PublisherInterface { return $this->p; }
+            public function createWithConfig(string $slug, array $config): PublisherInterface { return $this->p; }
+        };
+
+        return new PublisherSelector($repo, $provider, $factory, new NullLogger());
+    }
+
+    public function testDispatchCreatesJobsForPublishers(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $selector = $this->createSelector($publisher);
+        $factory = new ArticleFactory();
+        $dispatcher = new AsyncPublishingDispatcher($queue, $selector, $factory);
+
+        $article = new Article(1, 0, 'Title', 'Content', scheduledAt: new \DateTimeImmutable('2023-01-01 00:00:00'));
+        $dispatcher->dispatch($article);
+
+        $this->assertCount(1, $queue->jobs);
+        $job = $queue->jobs[0];
+        $this->assertSame('simple', $job->publisherKey);
+        $this->assertSame($factory->toArray($article), $job->payload);
+        $this->assertEquals($article->scheduledAt, $job->scheduledAt);
+    }
+
+    public function testDispatchAddsScheduledAtWhenMissing(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $selector = $this->createSelector($publisher);
+        $factory = new ArticleFactory();
+        $dispatcher = new AsyncPublishingDispatcher($queue, $selector, $factory);
+
+        $article = new Article(2, 0, 'Title2', 'Content2');
+        $this->assertNull($article->scheduledAt);
+        $dispatcher->dispatch($article);
+
+        $this->assertNotNull($article->scheduledAt);
+        $this->assertEquals($article->scheduledAt, $queue->jobs[0]->scheduledAt);
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory test stubs for queue and publisher
- create unit tests for `ArticleFactory` and `AsyncPublishingDispatcher`
- create integration tests for `JobRunner` and `Publisher`

## Testing
- `vendor/bin/phpunit --testdox`
- `vendor/bin/phpunit --coverage-text` *(fails: No code coverage driver with path coverage support available)*

------
https://chatgpt.com/codex/tasks/task_e_688aa0786c4c832981bb89e1ded09f65