### PR TITLE
Add unit tests for JobRunner and domain helpers

### DIFF
--- a/tests/Unit/Application/Service/Queue/JobRunnerTest.php
+++ b/tests/Unit/Application/Service/Queue/JobRunnerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Application\Service\Queue;
+
+use DateTimeImmutable;
+use N3XT0R\XPub\Application\Factory\ArticleFactory;
+use N3XT0R\XPub\Application\Publisher\PublisherSelector;
+use N3XT0R\XPub\Application\Service\Queue\JobRunner;
+use N3XT0R\XPub\Domain\Contracts\PublisherFactoryInterface;
+use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
+use N3XT0R\XPub\Domain\Entity\Article;
+use N3XT0R\XPub\Domain\Entity\Job;
+use N3XT0R\XPub\Domain\Entity\Publisher;
+use N3XT0R\XPub\Domain\Repository\PostStatusRepositoryInterface;
+use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
+use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
+use N3XT0R\XPub\Tests\Stubs\InMemoryQueue;
+use N3XT0R\XPub\Tests\Stubs\SimplePublisher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class JobRunnerTest extends TestCase
+{
+    private function createSelector(SimplePublisher $publisher): PublisherSelector
+    {
+        $entity = new Publisher('simple', 'Simple');
+        $repo = new class($entity) implements PublisherRepositoryInterface {
+            public function __construct(private Publisher $p) {}
+            public function all(): array { return [$this->p]; }
+            public function findBySlug(string $slug, ?string $purposeType = null): ?Publisher { return $this->p; }
+            public function updateConfig(string $slug, array $newConfig): bool { return true; }
+            public function create(string $slug, string $name, array $config): bool { return true; }
+        };
+        $settings = new class implements SettingsRepositoryInterface {
+            public function get(string $key, mixed $default = null): mixed { return ['simple']; }
+            public function set(string $key, mixed $value): bool { return true; }
+            public function delete(string $key): bool { return true; }
+        };
+        $provider = new PublisherTargetProvider($settings);
+        $factory = new class($publisher) implements PublisherFactoryInterface {
+            public function __construct(private PublisherInterface $p) {}
+            public function create(string $slug): PublisherInterface { return $this->p; }
+            public function createWithConfig(string $slug, array $config): PublisherInterface { return $this->p; }
+        };
+        return new PublisherSelector($repo, $provider, $factory, new NullLogger());
+    }
+
+    private function createRunner(SimplePublisher $publisher, InMemoryQueue $queue, bool $published): JobRunner
+    {
+        $selector = $this->createSelector($publisher);
+        $factory = new ArticleFactory();
+        $statusRepo = new class($published) implements PostStatusRepositoryInterface {
+            public function __construct(private bool $ok) {}
+            public function isPublishedAndNotOutdated(int $postId): bool { return $this->ok; }
+        };
+        return new JobRunner($queue, $selector, $factory, $statusRepo, new NullLogger());
+    }
+
+    public function testRunPublishesAndMarksDone(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $runner = $this->createRunner($publisher, $queue, true);
+
+        $factory = new ArticleFactory();
+        $article = new Article(1, 0, 'Title', 'Content', scheduledAt: new DateTimeImmutable('2024-01-01'));
+        $payload = $factory->toArray($article);
+        $queue->jobs[] = new Job(1, 'simple', $payload, $article->scheduledAt, 0, null, 5);
+
+        $runner->run();
+
+        $this->assertCount(1, $publisher->published);
+        $this->assertCount(1, $queue->done);
+        $this->assertEmpty($queue->failed);
+    }
+
+    public function testRunSkipsWhenUnpublished(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $runner = $this->createRunner($publisher, $queue, false);
+
+        $factory = new ArticleFactory();
+        $article = new Article(2, 0, 'T', 'C', scheduledAt: new DateTimeImmutable('2024-01-01'));
+        $queue->jobs[] = new Job(2, 'simple', $factory->toArray($article), $article->scheduledAt);
+
+        $runner->run();
+
+        $this->assertEmpty($publisher->published);
+        $this->assertEmpty($queue->done);
+        $this->assertEmpty($queue->failed);
+    }
+
+    public function testRunMarksFailedOnException(): void
+    {
+        $queue = new InMemoryQueue();
+        $publisher = new SimplePublisher();
+        $publisher->shouldFail = true;
+        $runner = $this->createRunner($publisher, $queue, true);
+
+        $factory = new ArticleFactory();
+        $article = new Article(3, 0, 'T', 'C', scheduledAt: new DateTimeImmutable('2024-01-01'));
+        $queue->jobs[] = new Job(3, 'simple', $factory->toArray($article), $article->scheduledAt);
+
+        $runner->run();
+
+        $this->assertCount(1, $queue->failed);
+        $this->assertEmpty($queue->done);
+    }
+}

--- a/tests/Unit/Domain/Entity/JobTest.php
+++ b/tests/Unit/Domain/Entity/JobTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Domain\Entity;
+
+use N3XT0R\XPub\Domain\Entity\Job;
+use PHPUnit\Framework\TestCase;
+
+final class JobTest extends TestCase
+{
+    public function testConstructorAssignsProperties(): void
+    {
+        $scheduled = new \DateTimeImmutable('2024-05-01 12:00:00');
+        $job = new Job(
+            5,
+            'devto',
+            ['foo' => 'bar'],
+            $scheduled,
+            2,
+            'err',
+            10
+        );
+
+        $this->assertSame(5, $job->postId);
+        $this->assertSame('devto', $job->publisherKey);
+        $this->assertSame(['foo' => 'bar'], $job->payload);
+        $this->assertSame($scheduled, $job->scheduledAt);
+        $this->assertSame(2, $job->attempts);
+        $this->assertSame('err', $job->lastError);
+        $this->assertSame(10, $job->id);
+    }
+}

--- a/tests/Unit/Domain/Hook/HookDefinitionTest.php
+++ b/tests/Unit/Domain/Hook/HookDefinitionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Domain\Hook;
+
+use N3XT0R\XPub\Domain\Hook\HookDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class HookDefinitionTest extends TestCase
+{
+    public function testPropertiesAreSetFromConstructor(): void
+    {
+        $callback = static fn() => 'ok';
+        $hook = new HookDefinition('save_post', $callback, 20, 3);
+
+        $this->assertSame('save_post', $hook->hookName);
+        $this->assertSame($callback, $hook->callback);
+        $this->assertSame(20, $hook->priority);
+        $this->assertSame(3, $hook->acceptedArgs);
+    }
+
+    public function testDefaultValues(): void
+    {
+        $callback = static fn() => null;
+        $hook = new HookDefinition('init', $callback);
+
+        $this->assertSame(10, $hook->priority);
+        $this->assertSame(1, $hook->acceptedArgs);
+    }
+}


### PR DESCRIPTION
## Summary
- add HookDefinition tests
- add Job entity tests
- add JobRunner service tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688aaa8e976c8329b105506ad9f12581