### PR TITLE
Refactor container instantiation

### DIFF
--- a/src/Adapter/WordpressCron.php
+++ b/src/Adapter/WordpressCron.php
@@ -7,7 +7,6 @@ namespace N3XT0R\XPub\Adapter;
 use DI\Container;
 use N3XT0R\XPub\Application\Service\Queue\JobRunner;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
-use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
 use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 
 final class WordpressCron
@@ -18,10 +17,15 @@ final class WordpressCron
 
     private static ?Container $container = null;
 
+    public static function setContainer(Container $container): void
+    {
+        self::$container = $container;
+    }
+
     private static function container(): Container
     {
         if (self::$container === null) {
-            self::$container = ContainerProvider::getContainer();
+            throw new \RuntimeException('Container not initialized');
         }
 
         return self::$container;

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -8,7 +8,6 @@ use DI\Container;
 use N3XT0R\XPub\Application\Service\Queue\AsyncPublishingDispatcher;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
 use N3XT0R\XPub\Domain\Hook\HookDispatcherInterface;
-use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
 use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\MetaBox;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsPageRegistrar;
@@ -33,10 +32,15 @@ final class WordpressPlugin
 {
     private static ?Container $container = null;
 
+    public static function setContainer(Container $container): void
+    {
+        self::$container = $container;
+    }
+
     private static function container(): Container
     {
         if (self::$container === null) {
-            self::$container = ContainerProvider::getContainer();
+            throw new \RuntimeException('Container not initialized');
         }
 
         return self::$container;

--- a/src/Infrastructure/Publishers/PublisherFactory.php
+++ b/src/Infrastructure/Publishers/PublisherFactory.php
@@ -9,17 +9,23 @@ use N3XT0R\XPub\Domain\Contracts\ConfigurablePublisherInterface;
 use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
 use N3XT0R\XPub\Domain\Contracts\SlugAwareInterface;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
-use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
+use DI\Container;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use RuntimeException;
 
 final class PublisherFactory
 {
     private static ?FilterDispatcherInterface $filterDispatcher = null;
+    private static ?Container $container = null;
 
     public static function setFilterDispatcher(FilterDispatcherInterface $dispatcher): void
     {
         self::$filterDispatcher = $dispatcher;
+    }
+
+    public static function setContainer(Container $container): void
+    {
+        self::$container = $container;
     }
 
     public static function create(string $target): PublisherInterface
@@ -77,7 +83,11 @@ final class PublisherFactory
 
     private static function instantiatePublisher(string $slug, string $class, array $config = []): PublisherInterface
     {
-        $instance = ContainerProvider::getContainer()->get($class);
+        if (!self::$container) {
+            throw new RuntimeException('Container not set');
+        }
+
+        $instance = self::$container->get($class);
 
         if (!$instance instanceof PublisherInterface) {
             throw new RuntimeException("Class '$class' must implement PublisherInterface");

--- a/src/Infrastructure/Wordpress/Updater/PluginUpdateManager.php
+++ b/src/Infrastructure/Wordpress/Updater/PluginUpdateManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Infrastructure\Wordpress\Updater;
 
-use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
+use DI\Container;
 use N3XT0R\XPub\Domain\Contracts\ReleaseProviderInterface;
 
 use function get_plugin_data;
@@ -28,9 +28,9 @@ class PluginUpdateManager
         $this->releaseService = $releaseService;
     }
 
-    public static function boot(string $pluginFile): void
+    public static function boot(string $pluginFile, Container $container): void
     {
-        ContainerProvider::getContainer()->make(self::class, [
+        $container->make(self::class, [
             'pluginFile' => plugin_basename($pluginFile),
             'pluginSlug' => 'xpub-multi-channel-publisher',
             'pluginInfoUrl' => 'https://github.com/N3XT0R/WP-XPub',

--- a/tests/Integration/Infrastructure/DI/ContainerProviderTest.php
+++ b/tests/Integration/Infrastructure/DI/ContainerProviderTest.php
@@ -10,6 +10,7 @@ class ContainerProviderTest extends TestCase
 {
     public function testReturnsSingletonContainer(): void
     {
+        ContainerProvider::setPluginMetadata(__FILE__, 'test', 'info');
         $c1 = ContainerProvider::getContainer();
         $c2 = ContainerProvider::getContainer();
         $this->assertInstanceOf(Container::class, $c1);

--- a/tests/Unit/Application/Factory/PublisherFactoryTest.php
+++ b/tests/Unit/Application/Factory/PublisherFactoryTest.php
@@ -3,6 +3,7 @@
 namespace N3XT0R\XPub\Tests\Application\Factory;
 
 use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
+use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
 use N3XT0R\XPub\Infrastructure\Publishers\DevToPublisher;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +21,8 @@ class PublisherFactoryTest extends TestCase
         };
 
         PublisherFactory::setFilterDispatcher($mockDispatcher);
+        ContainerProvider::setPluginMetadata(__FILE__, 'test', 'info');
+        PublisherFactory::setContainer(ContainerProvider::getContainer());
     }
 
     public function testCreateReturnsPublisher(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,13 @@ require __DIR__.'/../vendor/autoload.php';
 $GLOBALS['wp_options'] = [];
 $GLOBALS['wp_remote_post_response'] = ['response' => ['code' => 200], 'body' => ''];
 
+if (!function_exists('wp_get_environment_type')) {
+    function wp_get_environment_type(): string
+    {
+        return 'development';
+    }
+}
+
 if (!function_exists('apply_filters')) {
     function apply_filters($tag, $value)
     {

--- a/xpub-multi-channel-publisher.php
+++ b/xpub-multi-channel-publisher.php
@@ -15,9 +15,22 @@
  */
 
 use N3XT0R\XPub\Adapter\WordpressPlugin;
+use N3XT0R\XPub\Adapter\WordpressCron;
+use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
+use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 
 defined('ABSPATH') or die('No script kiddies please!');
 require_once __DIR__.'/vendor/autoload.php';
+
+ContainerProvider::setPluginMetadata(
+    __FILE__,
+    'xpub-multi-channel-publisher',
+    'https://github.com/N3XT0R/WP-XPub'
+);
+$container = ContainerProvider::getContainer();
+WordpressPlugin::setContainer($container);
+WordpressCron::setContainer($container);
+PublisherFactory::setContainer($container);
 
 WordpressPlugin::init(__FILE__);
 


### PR DESCRIPTION
## Summary
- inject the DI container into adapters instead of creating it lazily
- build the container once in `xpub-multi-channel-publisher.php`
- pass the container to `WordpressPlugin`, `WordpressCron` and `PublisherFactory`
- update tests to set plugin metadata and container
- provide a WordPress environment type in bootstrap for test runs

## Testing
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688b4542c0508329aa6e971c1bf3a067