### PR TITLE
Refactor tests and add stubs

### DIFF
--- a/tests/Integration/Infrastructure/DI/ContainerProviderTest.php
+++ b/tests/Integration/Infrastructure/DI/ContainerProviderTest.php
@@ -3,6 +3,7 @@
 namespace N3XT0R\XPub\Tests\Infrastructure\DI;
 
 use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
+use N3XT0R\XPub\Shared\Plugin\PluginContext;
 use PHPUnit\Framework\TestCase;
 use DI\Container;
 
@@ -10,7 +11,7 @@ class ContainerProviderTest extends TestCase
 {
     public function testReturnsSingletonContainer(): void
     {
-        ContainerProvider::setPluginMetadata(__FILE__, 'test', 'info');
+        ContainerProvider::setPluginContext(new PluginContext(__FILE__, 'test', 'info'));
         $c1 = ContainerProvider::getContainer();
         $c2 = ContainerProvider::getContainer();
         $this->assertInstanceOf(Container::class, $c1);

--- a/tests/Stubs/InMemorySettingsRepository.php
+++ b/tests/Stubs/InMemorySettingsRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Tests\Stubs;
+
+use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
+
+final class InMemorySettingsRepository implements SettingsRepositoryInterface
+{
+    /**
+     * @param array<string,mixed> $settings
+     */
+    public function __construct(private array $settings = []) {}
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->settings[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value): bool
+    {
+        $this->settings[$key] = $value;
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        unset($this->settings[$key]);
+        return true;
+    }
+}

--- a/tests/Unit/Application/Factory/PublisherFactoryTest.php
+++ b/tests/Unit/Application/Factory/PublisherFactoryTest.php
@@ -4,6 +4,7 @@ namespace N3XT0R\XPub\Tests\Application\Factory;
 
 use N3XT0R\XPub\Infrastructure\Publishers\PublisherFactory;
 use N3XT0R\XPub\Infrastructure\DI\ContainerProvider;
+use N3XT0R\XPub\Shared\Plugin\PluginContext;
 use N3XT0R\XPub\Domain\Hook\FilterDispatcherInterface;
 use N3XT0R\XPub\Infrastructure\Publishers\DevToPublisher;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +22,7 @@ class PublisherFactoryTest extends TestCase
         };
 
         PublisherFactory::setFilterDispatcher($mockDispatcher);
-        ContainerProvider::setPluginMetadata(__FILE__, 'test', 'info');
+        ContainerProvider::setPluginContext(new PluginContext(__FILE__, 'test', 'info'));
         PublisherFactory::setContainer(ContainerProvider::getContainer());
     }
 

--- a/tests/Unit/Application/Publisher/PublisherSelectorTest.php
+++ b/tests/Unit/Application/Publisher/PublisherSelectorTest.php
@@ -8,6 +8,7 @@ use N3XT0R\XPub\Domain\Contracts\PublisherInterface;
 use N3XT0R\XPub\Domain\Entity\Publisher;
 use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
 use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
+use N3XT0R\XPub\Tests\Stubs\InMemorySettingsRepository;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
@@ -23,11 +24,9 @@ class PublisherSelectorTest extends TestCase
         $publisherInstance = $this->createMock(PublisherInterface::class);
         $factory->method('createWithConfig')->with('test', [])->willReturn($publisherInstance);
 
-        $settings = new class implements \N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface {
-            public function get(string $key, mixed $default = null): mixed { return []; }
-            public function set(string $key, mixed $value): bool { return true; }
-            public function delete(string $key): bool { return true; }
-        };
+        $settings = new InMemorySettingsRepository([
+            'xpub_publisher_targets' => [],
+        ]);
         $targetProvider = new PublisherTargetProvider($settings);
         $selector = new PublisherSelector($repository, $targetProvider, $factory, new NullLogger());
         $this->assertSame($publisherInstance, $selector->get('test'));
@@ -38,11 +37,9 @@ class PublisherSelectorTest extends TestCase
         $repository = $this->createMock(PublisherRepositoryInterface::class);
         $repository->method('findBySlug')->willReturn(null);
 
-        $settings = new class implements \N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface {
-            public function get(string $key, mixed $default = null): mixed { return []; }
-            public function set(string $key, mixed $value): bool { return true; }
-            public function delete(string $key): bool { return true; }
-        };
+        $settings = new InMemorySettingsRepository([
+            'xpub_publisher_targets' => [],
+        ]);
         $targetProvider = new PublisherTargetProvider($settings);
         $selector = new PublisherSelector($repository, $targetProvider, $this->createMock(PublisherFactoryInterface::class));
         $this->expectException(\RuntimeException::class);
@@ -56,11 +53,9 @@ class PublisherSelectorTest extends TestCase
         $repository->method('findBySlug')->with('active')->willReturn($publisherEntity);
         $repository->method('all')->willReturn([$publisherEntity]);
 
-        $settings = new class implements \N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface {
-            public function get(string $key, mixed $default = null): mixed { return ['active']; }
-            public function set(string $key, mixed $value): bool { return true; }
-            public function delete(string $key): bool { return true; }
-        };
+        $settings = new InMemorySettingsRepository([
+            'xpub_publisher_targets' => ['active'],
+        ]);
         $targetProvider = new PublisherTargetProvider($settings);
 
         $factory = $this->createMock(PublisherFactoryInterface::class);

--- a/tests/Unit/Application/Service/Queue/AsyncPublishingDispatcherTest.php
+++ b/tests/Unit/Application/Service/Queue/AsyncPublishingDispatcherTest.php
@@ -13,8 +13,8 @@ use N3XT0R\XPub\Domain\Entity\Article;
 use N3XT0R\XPub\Domain\Entity\Publisher;
 use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
 use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
-use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
 use N3XT0R\XPub\Tests\Stubs\InMemoryQueue;
+use N3XT0R\XPub\Tests\Stubs\InMemorySettingsRepository;
 use N3XT0R\XPub\Tests\Stubs\SimplePublisher;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -33,11 +33,9 @@ final class AsyncPublishingDispatcherTest extends TestCase
             public function create(string $slug, string $name, array $config): bool { return true; }
         };
 
-        $settings = new class implements SettingsRepositoryInterface {
-            public function get(string $key, mixed $default = null): mixed { return ['simple']; }
-            public function set(string $key, mixed $value): bool { return true; }
-            public function delete(string $key): bool { return true; }
-        };
+        $settings = new InMemorySettingsRepository([
+            'xpub_publisher_targets' => ['simple'],
+        ]);
 
         $provider = new PublisherTargetProvider($settings);
 

--- a/tests/Unit/Application/Service/Queue/JobRunnerTest.php
+++ b/tests/Unit/Application/Service/Queue/JobRunnerTest.php
@@ -16,8 +16,8 @@ use N3XT0R\XPub\Domain\Entity\Publisher;
 use N3XT0R\XPub\Domain\Repository\PostStatusRepositoryInterface;
 use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
 use N3XT0R\XPub\Domain\Service\Publishing\PublisherTargetProvider;
-use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
 use N3XT0R\XPub\Tests\Stubs\InMemoryQueue;
+use N3XT0R\XPub\Tests\Stubs\InMemorySettingsRepository;
 use N3XT0R\XPub\Tests\Stubs\SimplePublisher;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -34,11 +34,9 @@ final class JobRunnerTest extends TestCase
             public function updateConfig(string $slug, array $newConfig): bool { return true; }
             public function create(string $slug, string $name, array $config): bool { return true; }
         };
-        $settings = new class implements SettingsRepositoryInterface {
-            public function get(string $key, mixed $default = null): mixed { return ['simple']; }
-            public function set(string $key, mixed $value): bool { return true; }
-            public function delete(string $key): bool { return true; }
-        };
+        $settings = new InMemorySettingsRepository([
+            'xpub_publisher_targets' => ['simple'],
+        ]);
         $provider = new PublisherTargetProvider($settings);
         $factory = new class($publisher) implements PublisherFactoryInterface {
             public function __construct(private PublisherInterface $p) {}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,13 @@ if (!function_exists('wp_remote_post')) {
         return $GLOBALS['wp_remote_post_response'];
     }
 }
+
+if (!function_exists('plugin_basename')) {
+    function plugin_basename(string $path): string
+    {
+        return basename($path);
+    }
+}
 if (!function_exists('is_wp_error')) {
     function is_wp_error($thing)
     {


### PR DESCRIPTION
## Summary
- create `InMemorySettingsRepository` stub
- use stub in publisher selector and queue service tests
- update container provider tests to use `PluginContext`
- stub `plugin_basename` in test bootstrap

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688b4d34b4b08329b60343ab0fb75765