### PR TITLE
Add developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ See the [developer docs](docs/index.md) for more:
 - [Architecture Overview](docs/architecture.md)
 - [Hooks & Filters](docs/hooks.md)
 - [Translations](docs/translations.md)
+- [Development Guide](docs/development.md)
 
 ---
 
@@ -112,6 +113,7 @@ All documentation is available in the `docs/` folder:
 - [Architecture](docs/architecture.md)
 - [Hooks & Filters](docs/hooks.md)
 - [Languages](docs/translations.md)
+- [Development Guide](docs/development.md)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,16 @@ When a post is saved, WP-XPub stores publishing jobs in its own queue table. A
 WordPress cron task runs every minute and processes pending jobs. This ensures
 that articles are published asynchronously without blocking the editor.
 
+## Dependency Injection
+
+All services are wired through [PHP-DI](https://php-di.org/). Default
+definitions live in `config/di.php` and in the `*ContainerConfigurator` classes
+under `src/*/DI/`.
+
+You can register your own configurator implementing
+`ContainerConfiguratorInterface` to override services or provide additional
+definitions.
+
 ---
 
 ## Benefits

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,58 @@
+# Developer Guide
+
+This guide explains how to set up a local environment for contributing to **WP-XPub** and how to extend it.
+
+## Setup
+
+1. Clone the repository and install the dependencies:
+   ```bash
+   git clone https://github.com/N3XT0R/WP-XPub.git
+   cd WP-XPub
+   composer install
+   ```
+
+2. Link the plugin into your WordPress `plugins/` directory or load it via Bedrock's `mu-plugins` folder.
+
+## Running Tests
+
+The project uses PHPUnit for its test suite. After installing the dependencies run:
+
+```bash
+vendor/bin/phpunit
+```
+
+The PHPUnit configuration is stored in `phpunit.xml`.
+
+## Dependency Injection Container
+
+WP-XPub uses [PHP-DI](https://php-di.org/) to wire its services. Default definitions live in `config/di.php` and the `\*ContainerConfigurator` classes under `src/*/DI/`.
+
+You can register your own services or override existing ones by implementing the `ContainerConfiguratorInterface`:
+
+```php
+use DI\ContainerBuilder;
+use N3XT0R\XPub\Shared\DI\ContainerConfiguratorInterface;
+
+class MyConfigurator implements ContainerConfiguratorInterface
+{
+    public function configure(ContainerBuilder $builder): void
+    {
+        $builder->addDefinitions([
+            // Your custom services
+        ]);
+    }
+}
+```
+
+Pass your configurator instance to the plugin bootstrap before calling `boot()`.
+
+## Packaging the Plugin
+
+A convenience script at `build/build.sh` creates a production-ready zip archive. Execute:
+
+```bash
+./build/build.sh
+```
+
+The script places the final package under `build/dist/`.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,3 +12,4 @@ Welcome to the documentation for WP-XPub, the flexible multi-channel auto publis
 - [Architecture](architecture.md)
 - [Queue & Scheduling](architecture.md#queue--scheduling)
 - [Translations](translations.md)
+- [Development Guide](development.md)


### PR DESCRIPTION
## Summary
- add a dedicated developer guide
- link to the new guide from README and docs index
- document dependency injection in architecture guide

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_688b4ee54f9483298f2e5974a3396b5c