### PR TITLE
Fix test bootstrap for wpdb

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -205,6 +205,10 @@ if (!class_exists('wpdb')) {
     }
 }
 
+if (!isset($GLOBALS['wpdb'])) {
+    $GLOBALS['wpdb'] = new wpdb();
+}
+
 if (!class_exists('http\\Exception\\InvalidArgumentException')) {
     class HttpInvalidArgumentException extends \InvalidArgumentException {}
     class_alias(HttpInvalidArgumentException::class, 'http\\Exception\\InvalidArgumentException');


### PR DESCRIPTION
## Summary
- set up `wpdb` global in the test bootstrap to remove warnings during tests

## Testing
- `vendor/bin/phpunit --testsuite unit --configuration phpunit.xml`
- `vendor/bin/phpunit --testsuite integration --configuration phpunit.xml`
- `vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_688b53f274908329ad9b325dc6531f28