### PR TITLE
docs: sync documentation with code

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,8 +40,22 @@ src/
 ## Queue & Scheduling
 
 When a post is saved, WP-XPub stores publishing jobs in its own queue table. A
-WordPress cron task runs every minute and processes pending jobs. This ensures
-that articles are published asynchronously without blocking the editor.
+WordPress cron task `xpub_run_job_runner` runs every minute (`xpub_every_minute`)
+and processes pending jobs.
+
+OAuth tokens are kept up to date by a second task `xpub_refresh_tokens`, which
+is scheduled every ten minutes (`xpub_every_ten_minutes`).
+
+Together these tasks ensure that articles are published asynchronously without
+blocking the editor and that token-based publishers stay authenticated.
+
+## OAuth-aware Publishers
+
+Publishers that work with OAuth tokens signal support by implementing
+`SupportsOAuthFactoryInterface`. The `PublisherFactory` automatically injects an
+`OAuthTokenProviderFactory` for these classes. To reduce boilerplate, publishers
+can include the `SupportsOAuthFactoryTrait`, which provides the required
+getter/setter implementation.
 
 ## Dependency Injection
 

--- a/docs/creating-publishers.md
+++ b/docs/creating-publishers.md
@@ -56,3 +56,20 @@ $map = apply_filters('wp_xpub_factory_map', self::getDefaultPublisherArray());
 The key `('example')` acts as the slug, and the value must be the fully qualified class name of a concrete publisher
 that extends `PublisherAbstract`
 
+### OAuth Support
+
+If your publisher needs OAuth credentials, implement
+`SupportsOAuthFactoryInterface`. This allows the core `PublisherFactory` to
+inject an `OAuthTokenProviderFactory` automatically. To skip writing the
+required getter and setter, include the `SupportsOAuthFactoryTrait`.
+
+```php
+use N3XT0R\XPub\Domain\Publishers\Contracts\SupportsOAuthFactoryInterface;
+use N3XT0R\XPub\Domain\Publishers\Traits\SupportsOAuthFactoryTrait;
+
+class MyOAuthPublisher extends PublisherAbstract implements SupportsOAuthFactoryInterface
+{
+    use SupportsOAuthFactoryTrait;
+}
+```
+

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,25 +1,27 @@
 # Hooks in WP-XPub
 
-WP-XPub supports the following pre- and post-publish hooks for full customization.
+WP-XPub fires hooks around the publish process for each configured publisher.
 
 ## Available Hooks
 
-### `xpub.before_publish`
-Fires before a post is published.
+### `xpub_pre_publish_{slug}`
+Filter executed before a post is published to a specific publisher. Replace `{slug}`
+with the publisher's slug (for example `devto`).
 
 **Example:**
 ```php
-add_action('xpub.before_publish', function ($publisherSlug, $article) {
-    // Custom logic before publishing
+add_filter('xpub_pre_publish_devto', function ($article, $publisher) {
+    // Modify the article before publishing to Dev.to
+    return $article;
 }, 10, 2);
 ```
 
-### `xpub.after_publish`
-Fires after a post is published.
+### `xpub_post_publish_{slug}`
+Action fired after a post has been published to a specific publisher.
 
 **Example:**
 ```php
-add_action('xpub.after_publish', function ($publisherSlug, $article, $success) {
-    // Custom logic after publishing
+add_action('xpub_post_publish_devto', function ($article, $success, $publisher) {
+    // Custom logic after publishing to Dev.to
 }, 10, 3);
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,9 @@ composer require n3xt0r/wp-xpub
    ```
 
 3. Activate the plugin via WordPress Admin > Plugins.
-4. WP-XPub registers a cron task automatically. Ensure WP Cron runs on your site or configure a real cron job to trigger it.
+4. WP-XPub registers cron tasks automatically (one for the job queue and one for
+   token refresh). Ensure WP Cron runs on your site or configure a real cron job
+   to trigger them.
 
 ---
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -224,13 +224,28 @@ add_filter('wp_xpub_oauth_provider_map', static function (array $map): array {
 ## ➡️ Using Providers in Custom Publishers
 
 Within your own publisher you can request a token provider for a given slug.
-This allows you to reuse the stored credentials and the automatic refresh logic.
+Publishers that rely on OAuth must implement
+`SupportsOAuthFactoryInterface`, which causes the `PublisherFactory` to inject
+an `OAuthTokenProviderFactory` instance automatically. To avoid writing the
+boilerplate getter and setter, include the `SupportsOAuthFactoryTrait`.
 
 ```php
+use N3XT0R\XPub\Domain\Publishers\Contracts\SupportsOAuthFactoryInterface;
+use N3XT0R\XPub\Domain\Publishers\Traits\SupportsOAuthFactoryTrait;
 use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
 
-$provider = OAuthTokenProviderFactory::createFromPublisherSlug('mastodon');
-$token = $provider->getAccessToken();
+class MyPublisher extends PublisherAbstract implements SupportsOAuthFactoryInterface
+{
+    use SupportsOAuthFactoryTrait;
+
+    protected function handlePublish(Article $article): bool
+    {
+        $provider = $this->getOAuthTokenProviderFactory()->createFromPublisherSlug('mastodon');
+        $token = $provider->getAccessToken();
+        // ...
+        return true;
+    }
+}
 ```
 
 Pass the provider into your publisher class or use it directly when publishing.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -2,13 +2,12 @@
 
 WP-XPub supports the following languages out of the box:
 
-| Language          | Locale  | Status                              |
-|-------------------|---------|-------------------------------------|
-| German            | `de_DE` | ✅ Active                            |
-| English (default) | `en_US` | ✅ Built-in                          |
-| French            | `fr_FR` | ✅ Active                            |
-| Spanish           | `es_ES` | ✅ Active                            |
-| Italian           | `it_IT` | ✅ Active                            |
-| Russian           | `ru_RU` | ✅ Active                            |
+| Language          | Locale  | Status             |
+|-------------------|---------|--------------------|
+| German            | `de_DE` | ✅ Active           |
+| English (default) | `en_US` | ✅ Built-in         |
+| French            | `fr_FR` | ✅ Active           |
+| Italian           | `it_IT` | ✅ Active           |
+| Russian           | `ru_RU` | ✅ Active           |
 
 Custom translations can be added to the `languages/` directory.


### PR DESCRIPTION
## Summary
- document slug-specific publish hooks
- note cron-based job runner and token refresh
- sync translations list with available locales
- document OAuth requirements for publishers

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688de52a84b48329981090d0b08f6b92