### PR TITLE
docs: update changelog for version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-08-02
+
+### Added
+
+- OAuth authentication for Mastodon publisher.
+- Separate cron for OAuth token refresh every 10 minutes.
+- Documentation for OAuth publisher requirements.
+
+### Changed
+
+- Improve response handling and error logging in Mastodon publisher.
+- Improve robustness of config update logic in `PublisherRepository`.
+
 ## [1.3.0] - 2025-07-31
 
 ### Added


### PR DESCRIPTION
## Summary
- document OAuth authentication and cron-based token refresh
- clarify Mastodon publisher error handling and configuration fixes

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688de8d912208329bbe8f80e3d163b2f