### PR TITLE
docs: update Mastodon and LinkedIn setup guides

### DIFF
--- a/docs/setup/linkedin.md
+++ b/docs/setup/linkedin.md
@@ -1,34 +1,61 @@
-# LinkedIn Publisher Setup
+# LinkedIn Publisher Setup Guide
 
-This guide explains how to configure the LinkedIn Publisher to automatically post articles to your LinkedIn personal
-profile or an organization page.
-
-## Requirements
-
-- A LinkedIn account
-- Admin access to a LinkedIn organization page (if posting as a company)
-- A configured redirect endpoint at `/xpub/v1/oauth/linkedin/callback`
-- Access to your WordPress admin area
+This guide explains how to configure the LinkedIn publisher in WP-XPub. The implementation uses LinkedIn's v2 API.
 
 ---
 
-## Step 1: Register a LinkedIn App
+## 🔐 Step 1: Register a LinkedIn App
 
 1. Visit: [https://www.linkedin.com/developers/apps](https://www.linkedin.com/developers/apps)
-2. Click **"Create App"**
-3. Fill out the required details:
-    - **App Name** (e.g., "WordPress Publisher")
-    - **Company/Organization**: Your personal name or an organization
-    - **App Logo**: Required (at least 100×100 PNG)
-    - **Privacy Policy URL**: Required (e.g., your site’s privacy or legal page)
-
-4. After creation, copy the following:
-    - `Client ID`
-    - `Client Secret`
+2. Click **"Create App"** and provide the required details:
+   - **App Name** (e.g., "WordPress Publisher")
+   - **Company/Organization**
+   - **App Logo** (at least 100×100 PNG)
+   - **Privacy Policy URL**
+3. In the app's **Auth** tab:
+   - Add the following **OAuth 2.0 scopes**:
+     - `w_member_social`
+     - `profile`
+     - `openid`
+   - Add the authorized redirect URL:
+     ```
+     https://yourdomain.com/wp-json/xpub/v1/oauth/linkedin/callback
+     ```
+4. Copy the generated `Client ID` and `Client Secret` for later use.
 
 ---
 
-## Step 2: Set Redirect URL
+## ⚙️ Step 2: Configure WP-XPub
 
-In the app's **"Auth"** tab, add this as an authorized redirect URL:
+In your WordPress admin dashboard:
+
+1. Navigate to **WP-XPub → OAuth Providers**
+2. Click **Add Provider**
+3. Select **Platform**: `LinkedIn`
+4. Fill in:
+   - **Client ID**
+   - **Client Secret**
+   - **Redirect URI**: (read-only, displayed for reference)
+
+Click **Save** when finished.
+
+---
+
+## 🔄 Step 3: Authorize the Account
+
+After saving the provider:
+
+1. Click **Connect** to start the LinkedIn OAuth flow.
+2. Sign in to LinkedIn and authorize the app.
+3. On success, WP-XPub stores the access token and author URN.
+
+The plugin can now publish posts to your LinkedIn profile.
+
+---
+
+## 📌 Notes
+
+- The publisher posts to the authenticated user's personal profile using the LinkedIn v2 API.
+- Required scopes: `w_member_social`, `profile`, `openid`.
+- Publishing to organization pages is not currently supported.
 

--- a/docs/setup/mastodon.md
+++ b/docs/setup/mastodon.md
@@ -12,7 +12,7 @@ This guide describes how to configure OAuth authentication for the Mastodon publ
     - **Application Name**: WP-XPub
     - **Redirect URI**:
       ```
-      https://yourdomain.com/wp-json/xpub/oauth/callback
+      https://yourdomain.com/wp-json/xpub/v1/oauth/mastodon/callback
       ```
     - **Scopes** (at minimum):
       ```
@@ -35,8 +35,8 @@ Go to your WordPress admin dashboard:
 4. Fill in:
     - **Client ID**: *(from previous step)*
     - **Client Secret**: *(from previous step)*
-    - **Instance Domain**: e.g. `mastodon.social`
-    - **Redirect URI**: (read-only, shown for convenience)
+    - **Instance Domain**: the domain of the server where you created the app (e.g. `mastodon.social`)
+    - **Redirect URI**: (read-only, shown for reference)
 
 Click **Save**.
 
@@ -54,6 +54,6 @@ WP-XPub will refresh tokens and publish posts automatically.
 ## 📌 Notes
 
 - Mastodon is a decentralized platform. This means every user belongs to an **instance** (server).
-- WP-XPub supports custom instances (e.g. `chaos.social`, `fosstodon.org`, etc.)
+- WP-XPub uses your instance's `/api/v1/statuses` endpoint to post the article title and URL.
 - Only `write:statuses` is required for publishing. Read scopes are optional.
 


### PR DESCRIPTION
## Summary
- clarify Mastodon OAuth callback path and add note about status endpoint
- rewrite LinkedIn setup guide for v2 API with required scopes and redirect URL

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6890171171c88329a97e29d16ce48b45