### PR TITLE
feat: add settings REST API and translations

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -1,7 +1,28 @@
+import { useEffect, useState } from 'react';
 import SettingsPage from './components/SettingsPage';
 
 export default function App() {
-  const settings = window.xpubSettings || {};
+  const { restUrl, restNonce } = window.xpubSettings || {};
+  const [settings, setSettings] = useState(null);
+
+  useEffect(() => {
+    if (!restUrl || !restNonce) {
+      return;
+    }
+    const base = restUrl.replace(/\/$/, '');
+    fetch(`${base}/xpub/v1/settings`, {
+      headers: {
+        'X-WP-Nonce': restNonce,
+      },
+    })
+      .then(res => res.json())
+      .then(data => setSettings({ ...data, restUrl }));
+  }, [restUrl, restNonce]);
+
+  if (!settings) {
+    return null;
+  }
+
   return <SettingsPage {...settings} />;
 }
 

--- a/frontend/components/SettingsPage.jsx
+++ b/frontend/components/SettingsPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { __ } from '@wordpress/i18n';
 
 export function SettingsPage({
   publishers = [],
@@ -61,12 +62,12 @@ export function SettingsPage({
             `width=${width},height=${height},top=${top},left=${left},resizable=yes,scrollbars=yes`
           );
         } else {
-          alert('No redirect URL received.');
+          alert(__('No redirect URL received.', 'xpub-multi-channel-publisher'));
         }
       })
       .catch(err => {
         console.error('OAuth error:', err);
-        alert('OAuth start failed.');
+        alert(__('OAuth start failed.', 'xpub-multi-channel-publisher'));
       });
 
     const interval = setInterval(() => {
@@ -75,7 +76,7 @@ export function SettingsPage({
         .then(data => {
           if (data.connected) {
             clearInterval(interval);
-            alert('OAuth erfolgreich!');
+            alert(__('OAuth erfolgreich!', 'xpub-multi-channel-publisher'));
             location.reload();
           }
         });
@@ -85,8 +86,10 @@ export function SettingsPage({
   const renderGroup = (publisher, purposeType, group) => {
     const heading =
       purposeType === 'oauth'
-        ? 'OAuth Settings'
-        : `${purposeType.charAt(0).toUpperCase() + purposeType.slice(1)} Settings`;
+        ? `${__('OAuth', 'xpub-multi-channel-publisher')} ${__('Settings', 'xpub-multi-channel-publisher')}`
+        : `${
+            purposeType.charAt(0).toUpperCase() + purposeType.slice(1)
+          } ${__('Settings', 'xpub-multi-channel-publisher')}`;
 
     return (
       <div key={purposeType} className="mt-6">
@@ -103,7 +106,7 @@ export function SettingsPage({
           return (
             <div key={key} className="mb-4">
               <label htmlFor={inputId} className="block font-bold mb-1">
-                {key}
+                {__(key, 'xpub-multi-channel-publisher')}
               </label>
               <input
                 type={type}
@@ -124,7 +127,7 @@ export function SettingsPage({
               className="button button-secondary"
               onClick={() => startOAuth(publisher.slug)}
             >
-              Authenticate with {publisher.name}
+              {`${__('Authenticate with', 'xpub-multi-channel-publisher')} ${publisher.name}`}
             </button>
           </div>
         )}
@@ -137,9 +140,9 @@ export function SettingsPage({
       <input type="hidden" name="action" value="xpub_save_settings" />
       <input type="hidden" name="_wpnonce" value={nonce} />
 
-      <h2 className="text-xl font-bold mb-4">Activate Publisher</h2>
+      <h2 className="text-xl font-bold mb-4">{__('Activate Publisher', 'xpub-multi-channel-publisher')}</h2>
       <fieldset className="mb-8">
-        <legend className="mb-2">Select active publishers:</legend>
+        <legend className="mb-2">{__('Select active publishers:', 'xpub-multi-channel-publisher')}</legend>
         {publishers.map(publisher => {
           const id = `publisher_${publisher.slug}`;
           return (
@@ -159,7 +162,7 @@ export function SettingsPage({
         })}
       </fieldset>
 
-      <h2 className="text-xl font-bold mb-4">Configuration</h2>
+      <h2 className="text-xl font-bold mb-4">{__('Configuration', 'xpub-multi-channel-publisher')}</h2>
       {publishers
         .filter(publisher => active.has(publisher.slug))
         .map(publisher => (
@@ -168,7 +171,7 @@ export function SettingsPage({
             className="mt-8 p-4 border border-gray-300"
           >
             <legend className="font-bold">
-              {publisher.name} Configuration
+              {`${publisher.name} ${__('Configuration', 'xpub-multi-channel-publisher')}`}
             </legend>
             {Object.entries(publisher.config || {}).map(([purposeType, group]) =>
               renderGroup(publisher, purposeType, group)
@@ -178,7 +181,7 @@ export function SettingsPage({
 
       <p className="mt-8">
         <button type="submit" className="button button-primary">
-          Save settings
+          {__('Save settings', 'xpub-multi-channel-publisher')}
         </button>
       </p>
     </form>

--- a/resources/views/admin/react-settings-page.php
+++ b/resources/views/admin/react-settings-page.php
@@ -1,2 +1,7 @@
 <div id="root"></div>
-muh
+<script>
+window.xpubSettings = {
+    restUrl: <?php echo json_encode(rest_url()); ?>,
+    restNonce: <?php echo json_encode(wp_create_nonce('wp_rest')); ?>
+};
+</script>

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -18,6 +18,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Logging\LoggerFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Presentation\AdminNoticePresenter;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\SettingsController;
 use N3XT0R\XPub\Infrastructure\Wordpress\Service\Plugin\PluginBootstrapService;
 use N3XT0R\XPub\Infrastructure\Wordpress\Setup\SetupRunner;
 use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
@@ -62,6 +63,7 @@ final class WordpressPlugin
             'saveHandler' => self::container()->get(SettingsSaveHandler::class),
             'oauthController' => self::container()->get(OAuthController::class),
             'updateManager' => $updateManager,
+            'settingsController' => self::container()->get(SettingsController::class),
         ]);
 
         $registrar = new WordpressHookRegistrar(

--- a/src/Application/Service/Admin/PublisherSettingsService.php
+++ b/src/Application/Service/Admin/PublisherSettingsService.php
@@ -32,4 +32,17 @@ final class PublisherSettingsService
             'activePublisherSlugs' => $active
         ];
     }
+
+    public function saveSettings(array $activePublisherSlugs, array $publisherConfigs): void
+    {
+        $this->settingsRepo->set('xpub_publisher_targets', $activePublisherSlugs);
+
+        foreach ($publisherConfigs as $slug => $configs) {
+            if (!is_array($configs) || $slug === '') {
+                continue;
+            }
+
+            $this->publisherRepo->updateConfig($slug, $configs);
+        }
+    }
 }

--- a/src/Infrastructure/DI/InfrastructureContainerConfigurator.php
+++ b/src/Infrastructure/DI/InfrastructureContainerConfigurator.php
@@ -39,6 +39,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WPDBQueueRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\WpPostStatusRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\SettingsController;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
@@ -86,6 +87,7 @@ final readonly class InfrastructureContainerConfigurator implements ContainerCon
             MetaBox::class => autowire(MetaBox::class),
             LoggerInterface::class => factory(fn() => LoggerFactory::create()),
             OAuthController::class => autowire(OAuthController::class),
+            SettingsController::class => autowire(SettingsController::class),
             ClearContainerCacheInterface::class => create(ContainerCacheCleaner::class)
                 ->constructor(get(PluginContext::class)),
             PluginUpdateManager::class => create()->constructor(

--- a/src/Infrastructure/Wordpress/Hook/HookProvider.php
+++ b/src/Infrastructure/Wordpress/Hook/HookProvider.php
@@ -8,6 +8,7 @@ use N3XT0R\XPub\Adapter\WordpressPlugin;
 use N3XT0R\XPub\Domain\Hook\HookDefinition;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\SettingsController;
 use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 
 final class HookProvider
@@ -16,6 +17,7 @@ final class HookProvider
         private readonly SettingsSaveHandler $saveHandler,
         private readonly OAuthController $oauthController,
         private readonly PluginUpdateManager $updateManager,
+        private readonly SettingsController $settingsController,
     ) {
     }
 
@@ -38,6 +40,7 @@ final class HookProvider
             ),
             new HookDefinition('init', fn() => $this->updateManager->register()),
             new HookDefinition('rest_api_init', [$this->oauthController, 'register']),
+            new HookDefinition('rest_api_init', [$this->settingsController, 'register']),
         ];
     }
 }

--- a/src/Infrastructure/Wordpress/Rest/SettingsController.php
+++ b/src/Infrastructure/Wordpress/Rest/SettingsController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Infrastructure\Wordpress\Rest;
+
+use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class SettingsController
+{
+    public function __construct(private PublisherSettingsService $service)
+    {
+    }
+
+    public function register(): void
+    {
+        register_rest_route('xpub/v1', '/settings', [
+            'methods' => 'GET',
+            'callback' => [$this, 'getSettings'],
+            'permission_callback' => fn() => current_user_can('manage_options'),
+        ]);
+
+        register_rest_route('xpub/v1', '/settings', [
+            'methods' => 'POST',
+            'callback' => [$this, 'saveSettings'],
+            'permission_callback' => fn() => current_user_can('manage_options'),
+        ]);
+    }
+
+    public function getSettings(WP_REST_Request $request): WP_REST_Response
+    {
+        $data = $this->service->getSettingsViewData();
+        $data['nonce'] = wp_create_nonce('xpub_save_settings');
+        $data['actionUrl'] = admin_url('admin-post.php');
+        $data['restUrl'] = rest_url();
+
+        return new WP_REST_Response($data);
+    }
+
+    public function saveSettings(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $params = $request->get_json_params();
+        $active = isset($params['active_publishers']) && is_array($params['active_publishers'])
+            ? array_map('sanitize_text_field', $params['active_publishers'])
+            : [];
+        $configs = isset($params['config']) && is_array($params['config']) ? $params['config'] : [];
+
+        try {
+            $this->service->saveSettings($active, $configs);
+        } catch (\Throwable $e) {
+            return new WP_Error('xpub_settings_save_failed', $e->getMessage(), ['status' => 500]);
+        }
+
+        return new WP_REST_Response(['success' => true]);
+    }
+}

--- a/tests/Integration/Infrastructure/Wordpress/Hook/HookProviderTest.php
+++ b/tests/Integration/Infrastructure/Wordpress/Hook/HookProviderTest.php
@@ -6,12 +6,14 @@ namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Hook;
 
 use N3XT0R\XPub\Domain\Hook\HookDefinition;
 use N3XT0R\XPub\Infrastructure\DI\Cache\ContainerCacheCleaner;
+use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
 use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\SettingsController;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Shared\Plugin\PluginContext;
@@ -22,6 +24,13 @@ class HookProviderTest extends TestCase
 {
     public function testItProvidesExpectedHooks(): void
     {
+        $settingsController = new SettingsController(
+            new PublisherSettingsService(
+                new PublisherRepository(),
+                new WordpressSettingsRepository()
+            )
+        );
+
         $provider = new HookProvider(
             new SettingsSaveHandler(
                 new SettingsFormRequestValidator(),
@@ -44,7 +53,8 @@ class HookProviderTest extends TestCase
                 ),
                 new \N3XT0R\XPub\Application\Update\ReleaseService(),
                 new ContainerCacheCleaner($context)
-            )
+            ),
+            $settingsController
         );
         $hooks = $provider->getHooks();
 

--- a/tests/Integration/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
+++ b/tests/Integration/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
@@ -6,6 +6,7 @@ namespace N3XT0R\XPub\Tests\Infrastructure\Wordpress\Hook;
 
 use N3XT0R\XPub\Application\Update\ReleaseService;
 use N3XT0R\XPub\Infrastructure\DI\Cache\ContainerCacheCleaner;
+use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
 use N3XT0R\XPub\Infrastructure\OAuth\OAuthTokenProviderFactory;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\Validator\SettingsFormRequestValidator;
@@ -13,6 +14,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookProvider;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\WordpressHookRegistrar;
 use N3XT0R\XPub\Infrastructure\Wordpress\Repository\PublisherRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Rest\OAuthController;
+use N3XT0R\XPub\Infrastructure\Wordpress\Rest\SettingsController;
 use N3XT0R\XPub\Infrastructure\Wordpress\Settings\WordpressSettingsRepository;
 use N3XT0R\XPub\Infrastructure\Wordpress\Updater\PluginUpdateManager;
 use N3XT0R\XPub\Shared\Plugin\PluginContext;
@@ -24,6 +26,13 @@ final class WordpressHookRegistrarTest extends TestCase
 {
     public function testItDispatchesAllHooksFromProvider(): void
     {
+        $settingsController = new SettingsController(
+            new PublisherSettingsService(
+                new PublisherRepository(),
+                new WordpressSettingsRepository()
+            )
+        );
+
         $provider = new HookProvider(
             new SettingsSaveHandler(
                 new SettingsFormRequestValidator(),
@@ -46,7 +55,8 @@ final class WordpressHookRegistrarTest extends TestCase
                 ),
                 new ReleaseService(),
                 new ContainerCacheCleaner($context)
-            )
+            ),
+            $settingsController
         );
         $dispatcher = new DummyDispatcher();
         $registrar = new WordpressHookRegistrar($provider, $dispatcher, []);

--- a/tests/Unit/Domain/Service/Admin/PublisherSettingsServiceTest.php
+++ b/tests/Unit/Domain/Service/Admin/PublisherSettingsServiceTest.php
@@ -45,4 +45,20 @@ final class PublisherSettingsServiceTest extends TestCase
 
         $this->assertSame(['devto'], $result['activePublisherSlugs']);
     }
+
+    public function testSaveSettingsPersistsData(): void
+    {
+        $publisherRepo = $this->createMock(PublisherRepositoryInterface::class);
+        $settingsRepo = $this->createMock(SettingsRepositoryInterface::class);
+
+        $publisherRepo->expects($this->once())
+            ->method('updateConfig')
+            ->with('devto', ['api_key' => 'secret']);
+        $settingsRepo->expects($this->once())
+            ->method('set')
+            ->with('xpub_publisher_targets', ['devto']);
+
+        $service = new PublisherSettingsService($publisherRepo, $settingsRepo);
+        $service->saveSettings(['devto'], ['devto' => ['api_key' => 'secret']]);
+    }
 }


### PR DESCRIPTION
## Summary
- add REST controller providing settings data and save endpoint
- expose settings via new service method and wire controller
- translate SettingsPage React component strings

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68908fc9a0148329b3e0b7b65419a9dd