### PR TITLE
Fix SettingsController instantiation in tests

### DIFF
--- a/tests/Integration/Infrastructure/Wordpress/Hook/HookProviderTest.php
+++ b/tests/Integration/Infrastructure/Wordpress/Hook/HookProviderTest.php
@@ -24,19 +24,22 @@ class HookProviderTest extends TestCase
 {
     public function testItProvidesExpectedHooks(): void
     {
+        $settingsSaveHandler = new SettingsSaveHandler(
+            new SettingsFormRequestValidator(),
+            new WordpressSettingsRepository(),
+            new PublisherRepository(),
+        );
+
         $settingsController = new SettingsController(
             new PublisherSettingsService(
                 new PublisherRepository(),
                 new WordpressSettingsRepository()
-            )
+            ),
+            $settingsSaveHandler
         );
 
         $provider = new HookProvider(
-            new SettingsSaveHandler(
-                new SettingsFormRequestValidator(),
-                new WordpressSettingsRepository(),
-                new PublisherRepository(),
-            ),
+            $settingsSaveHandler,
             new OAuthController(
                 new OAuthTokenProviderFactory(
                     new PublisherRepository(),

--- a/tests/Integration/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
+++ b/tests/Integration/Infrastructure/Wordpress/Hook/WordpressHookRegistrarTest.php
@@ -26,19 +26,22 @@ final class WordpressHookRegistrarTest extends TestCase
 {
     public function testItDispatchesAllHooksFromProvider(): void
     {
+        $settingsSaveHandler = new SettingsSaveHandler(
+            new SettingsFormRequestValidator(),
+            new WordpressSettingsRepository(),
+            new PublisherRepository(),
+        );
+
         $settingsController = new SettingsController(
             new PublisherSettingsService(
                 new PublisherRepository(),
                 new WordpressSettingsRepository()
-            )
+            ),
+            $settingsSaveHandler
         );
 
         $provider = new HookProvider(
-            new SettingsSaveHandler(
-                new SettingsFormRequestValidator(),
-                new WordpressSettingsRepository(),
-                new PublisherRepository(),
-            ),
+            $settingsSaveHandler,
             new OAuthController(
                 new OAuthTokenProviderFactory(
                     new PublisherRepository(),


### PR DESCRIPTION
## Summary
- ensure SettingsController is constructed with SettingsSaveHandler in integration tests

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6891566a20f883299509ec66f0bf4f4b