### PR TITLE
refactor: decouple infrastructure from application

### DIFF
--- a/src/Application/DI/ApplicationContainerConfigurator.php
+++ b/src/Application/DI/ApplicationContainerConfigurator.php
@@ -5,14 +5,22 @@ declare(strict_types=1);
 namespace N3XT0R\XPub\Application\DI;
 
 use DI\ContainerBuilder;
+use N3XT0R\XPub\Application\Publisher\PublisherSelector;
+use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
+use N3XT0R\XPub\Application\Update\ReleaseService;
+use N3XT0R\XPub\Domain\Service\Admin\PublisherSettingsServiceInterface;
 use N3XT0R\XPub\Shared\DI\ContainerConfiguratorInterface;
+
+use function DI\autowire;
 
 class ApplicationContainerConfigurator implements ContainerConfiguratorInterface
 {
     public function configure(ContainerBuilder $builder): void
     {
         $builder->addDefinitions([
-            // Application Services
+            PublisherSettingsServiceInterface::class => autowire(PublisherSettingsService::class),
+            PublisherSelector::class => autowire(PublisherSelector::class),
+            ReleaseService::class => autowire(ReleaseService::class),
         ]);
     }
 }

--- a/src/Application/Service/Admin/PublisherSettingsService.php
+++ b/src/Application/Service/Admin/PublisherSettingsService.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace N3XT0R\XPub\Application\Service\Admin;
 
 use N3XT0R\XPub\Domain\Repository\PublisherRepositoryInterface;
+use N3XT0R\XPub\Domain\Service\Admin\PublisherSettingsServiceInterface;
 use N3XT0R\XPub\Domain\Settings\SettingsRepositoryInterface;
 
-final class PublisherSettingsService
+final class PublisherSettingsService implements PublisherSettingsServiceInterface
 {
     public function __construct(
         private PublisherRepositoryInterface $publisherRepo,

--- a/src/Domain/Contracts/ClearContainerCacheInterface.php
+++ b/src/Domain/Contracts/ClearContainerCacheInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace N3XT0R\XPub\Application\Cache;
+namespace N3XT0R\XPub\Domain\Contracts;
 
 
 interface ClearContainerCacheInterface

--- a/src/Domain/Service/Admin/PublisherSettingsServiceInterface.php
+++ b/src/Domain/Service/Admin/PublisherSettingsServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Domain\Service\Admin;
+
+interface PublisherSettingsServiceInterface
+{
+    public function getSettingsViewData(): array;
+
+    public function saveSettings(array $activePublisherSlugs, array $publisherConfigs): void;
+}
+

--- a/src/Infrastructure/DI/Cache/ContainerCacheCleaner.php
+++ b/src/Infrastructure/DI/Cache/ContainerCacheCleaner.php
@@ -2,7 +2,7 @@
 
 namespace N3XT0R\XPub\Infrastructure\DI\Cache;
 
-use N3XT0R\XPub\Application\Cache\ClearContainerCacheInterface;
+use N3XT0R\XPub\Domain\Contracts\ClearContainerCacheInterface;
 use N3XT0R\XPub\Shared\Plugin\PluginContext;
 
 final readonly class ContainerCacheCleaner implements ClearContainerCacheInterface

--- a/src/Infrastructure/DI/InfrastructureContainerConfigurator.php
+++ b/src/Infrastructure/DI/InfrastructureContainerConfigurator.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace N3XT0R\XPub\Infrastructure\DI;
 
 use DI\ContainerBuilder;
-use N3XT0R\XPub\Application\Cache\ClearContainerCacheInterface;
-use N3XT0R\XPub\Application\Publisher\PublisherSelector;
-use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
-use N3XT0R\XPub\Application\Update\ReleaseService;
+use N3XT0R\XPub\Domain\Contracts\ClearContainerCacheInterface;
 use N3XT0R\XPub\Domain\Contracts\Factory\ArticleFactoryInterface;
 use N3XT0R\XPub\Domain\Contracts\Factory\WordpressArticleFactoryInterface;
 use N3XT0R\XPub\Domain\Contracts\HtmlToMarkdownRendererInterface;
@@ -84,27 +81,13 @@ final readonly class InfrastructureContainerConfigurator implements ContainerCon
             SettingsSaveHandler::class => autowire(SettingsSaveHandler::class),
             ReactAppLoader::class => autowire(ReactAppLoader::class),
             XPubSettingsAppLoader::class => autowire(XPubSettingsAppLoader::class),
-            SettingsPageRegistrar::class => create()->constructor(
-                get(PublisherSettingsService::class),
-                get(XPubSettingsAppLoader::class),
-            ),
+            SettingsPageRegistrar::class => autowire(SettingsPageRegistrar::class),
             MetaBox::class => autowire(MetaBox::class),
             LoggerInterface::class => factory(fn() => LoggerFactory::create()),
             OAuthController::class => autowire(OAuthController::class),
             SettingsController::class => autowire(SettingsController::class),
-            ClearContainerCacheInterface::class => create(ContainerCacheCleaner::class)
-                ->constructor(get(PluginContext::class)),
-            PluginUpdateManager::class => create()->constructor(
-                get(PluginContext::class),
-                autowire(ReleaseService::class),
-                get(ClearContainerCacheInterface::class)
-            ),
-            PublisherSelector::class => create()->constructor(
-                get(PublisherRepositoryInterface::class),
-                get(PublisherTargetProvider::class),
-                get(PublisherFactoryInterface::class),
-                get(LoggerInterface::class)
-            ),
+            ClearContainerCacheInterface::class => autowire(ContainerCacheCleaner::class),
+            PluginUpdateManager::class => autowire(PluginUpdateManager::class),
 
         ]);
     }

--- a/src/Infrastructure/Wordpress/Admin/SettingsPageRegistrar.php
+++ b/src/Infrastructure/Wordpress/Admin/SettingsPageRegistrar.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Infrastructure\Wordpress\Admin;
 
-use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
+use N3XT0R\XPub\Domain\Service\Admin\PublisherSettingsServiceInterface;
 use N3XT0R\XPub\Infrastructure\Wordpress\Hook\HookRegistrableInterface;
 use N3XT0R\XPub\Infrastructure\Wordpress\React\Components\XPubSettingsAppLoader;
 use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
@@ -12,7 +12,7 @@ use N3XT0R\XPub\Infrastructure\Wordpress\View\View;
 final class SettingsPageRegistrar implements HookRegistrableInterface
 {
     public function __construct(
-        private PublisherSettingsService $service,
+        private PublisherSettingsServiceInterface $service,
         private XPubSettingsAppLoader $appLoader,
     ) {
     }

--- a/src/Infrastructure/Wordpress/Rest/SettingsController.php
+++ b/src/Infrastructure/Wordpress/Rest/SettingsController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Infrastructure\Wordpress\Rest;
 
-use N3XT0R\XPub\Application\Service\Admin\PublisherSettingsService;
+use N3XT0R\XPub\Domain\Service\Admin\PublisherSettingsServiceInterface;
 use N3XT0R\XPub\Infrastructure\Wordpress\Admin\SettingsSaveHandler;
 use WP_Error;
 use WP_REST_Request;
@@ -12,7 +12,7 @@ use WP_REST_Response;
 
 class SettingsController
 {
-    public function __construct(private PublisherSettingsService $service, private SettingsSaveHandler $handler)
+    public function __construct(private PublisherSettingsServiceInterface $service, private SettingsSaveHandler $handler)
     {
     }
 

--- a/src/Infrastructure/Wordpress/Updater/PluginUpdateManager.php
+++ b/src/Infrastructure/Wordpress/Updater/PluginUpdateManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace N3XT0R\XPub\Infrastructure\Wordpress\Updater;
 
-use N3XT0R\XPub\Application\Cache\ClearContainerCacheInterface;
+use N3XT0R\XPub\Domain\Contracts\ClearContainerCacheInterface;
 use N3XT0R\XPub\Domain\Contracts\ReleaseProviderInterface;
 use N3XT0R\XPub\Shared\Plugin\PluginContext;
 


### PR DESCRIPTION
## Summary
- move ClearContainerCacheInterface to Domain contracts and autowire cache cleaner
- introduce PublisherSettingsServiceInterface for infrastructure components
- isolate InfrastructureContainerConfigurator from Application namespace

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6891e9d681108329b93887456d533bdd