### PR TITLE
docs: add 1.6.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2025-08-05
+
+### Added
+
+- React-based admin settings page built with Vite and Tailwind.
+- Settings REST API endpoints with translation support.
+- Internationalization JSON files for the settings interface.
+
+### Changed
+
+- Decoupled infrastructure layer from the application.
+- Settings loader now passes React app configuration.
+
+### Fixed
+
+- Corrected SettingsController instantiation in tests.
+
 ## [1.5.0] - 2025-08-04
 
 ### Added


### PR DESCRIPTION
## Summary
- add changelog entry for 1.6.0 with React settings UI and REST API
- note infrastructure decoupling and test fix

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68921969af788329b41ca6d5a0df2946